### PR TITLE
Separate link extraction from content fetch to speed up email reading

### DIFF
--- a/skills/mail_assistant/SKILL.md
+++ b/skills/mail_assistant/SKILL.md
@@ -37,10 +37,10 @@ Email search can be slow (10-30s) because Mail.app processes messages one by one
 **Always use a two-phase approach to minimize search time:**
 
 1. **Phase 1 — Find (headers only):** Search with the most specific filters possible, `with_content=false` (default), small `limit` (5), and narrow `days` (7 unless user says otherwise). Combine `sender` AND `subject` in a single call when both are known.
-2. **Phase 2 — Read (by message_id):** Once you find the right email, fetch its content with `message_id` + `with_content=true`. Message-ID lookup is near-instant (<1s).
+2. **Phase 2 — Read (by message_id):** Once you find the right email, fetch its content with `message_id` + `with_content=true`. Message-ID lookup with content takes ~3-5s per email. Add `with_links=true` only when the user needs URLs from HTML emails (adds ~5s extra).
 
 **Bad:** `search_emails(subject="Ferien", days=30, with_content=True)` → slow (30s+, fetches all bodies)
-**Good:** `search_emails(subject="Ferien", sender="mom", days=7, limit=5)` → fast headers → then `search_emails(message_id="<id>", with_content=True)` → instant
+**Good:** `search_emails(subject="Ferien", sender="mom", days=7, limit=5)` → fast headers → then `search_emails(message_id="<id>", with_content=True)` → ~3-5s
 
 ### Search Optimization Rules
 - **Combine filters:** Use both `sender` + `subject` in one call instead of two separate searches

--- a/src/macbot/tasks/macos_automation.py
+++ b/src/macbot/tasks/macos_automation.py
@@ -147,7 +147,8 @@ class SearchEmailsTask(Task):
             "Search emails in Mail.app. Can search by sender, subject, message_id, or list all emails in an account. "
             "IMPORTANT: 'emails from X account' means emails RECEIVED BY that account (use account parameter), "
             "not emails FROM that sender. Use message_id for precise lookup of a specific email. "
-            "Use with_content=True to include the full email body text (needed to read what an email says)."
+            "Use with_content=True to include the full email body text (needed to read what an email says). "
+            "Add with_links=True to also extract hyperlinks from HTML emails (slower, only when URLs are needed)."
         )
 
     async def execute(
@@ -161,6 +162,7 @@ class SearchEmailsTask(Task):
         days: int | None = None,
         all_mailboxes: bool = False,
         with_content: bool = False,
+        with_links: bool = False,
         limit: int = 20
     ) -> dict[str, Any]:
         """Search emails.
@@ -175,6 +177,7 @@ class SearchEmailsTask(Task):
             days: Only return emails from the last N days.
             all_mailboxes: Search all mailboxes including Sent, Trash, etc.
             with_content: Include the full email body text (use when you need to read the email content).
+            with_links: Also extract hyperlinks from HTML email source (slower, use only when URLs are needed). Requires with_content.
             limit: Maximum number of results to return.
 
         Returns:
@@ -202,6 +205,8 @@ class SearchEmailsTask(Task):
             args.append("--all-mailboxes")
         if with_content:
             args.append("--with-content")
+        if with_links:
+            args.append("--with-links")
         args.extend(["--limit", str(limit)])
 
         return await run_script("mail/search-emails.sh", args, timeout=60)


### PR DESCRIPTION
with_content=True now only fetches the plain text body (~3-5s) instead of also fetching the full MIME source and running link extraction (~10s). A new --with-links flag enables the old behavior when URLs are needed.