### PR TITLE
Add subagent system for delegating focused tasks to child agents

### DIFF
--- a/src/macbot/config.py
+++ b/src/macbot/config.py
@@ -139,6 +139,18 @@ Before starting a task, check `get_agent_memory` to see recent context and avoid
         default=2,
         description="Maximum concurrent tasks in subagent lane",
     )
+    subagent_model: str = Field(
+        default="",
+        description="Override model for subagents (empty = auto by tier)",
+    )
+    subagent_max_iterations: int = Field(
+        default=30,
+        description="Maximum iterations for subagent loops",
+    )
+    subagent_timeout: int = Field(
+        default=120,
+        description="Timeout in seconds for subagent execution",
+    )
     queue_warn_after_ms: int = Field(
         default=5000,
         description="Warning threshold for queue wait time in milliseconds",

--- a/src/macbot/core/subagent.py
+++ b/src/macbot/core/subagent.py
@@ -1,0 +1,283 @@
+"""Subagent orchestration for delegating focused tasks.
+
+A subagent is a fresh Agent instance with a scoped tool registry,
+an optional cheaper model, and an isolated conversation context.
+Subagents run to completion and return a summary string.
+"""
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from macbot.config import Settings
+from macbot.tasks.registry import TaskRegistry
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+PROVIDER_FAST_MODELS: dict[str, str] = {
+    "anthropic": "anthropic/claude-haiku-4-5-20251001",
+    "openai": "openai/gpt-4o-mini",
+    "openrouter": "openrouter/anthropic/claude-haiku-4-5-20251001",
+}
+
+PROFILE_TOOLS: dict[str, set[str]] = {
+    "mail_research": {
+        "search_emails",
+        "get_unread_emails",
+        "download_attachments",
+        "mark_emails_read",
+        "check_email_processed",
+        "mark_email_processed",
+        "get_agent_memory",
+        "get_current_time",
+        "read_file",
+    },
+    "calendar_planner": {
+        "get_today_events",
+        "get_week_events",
+        "create_calendar_event",
+        "list_calendars",
+        "get_due_today_reminders",
+        "create_reminder",
+        "get_current_time",
+        "search_emails",
+    },
+    "web_researcher": {
+        "web_fetch",
+        "web_search",
+        "fetch_url",
+        "browser_navigate",
+        "browser_snapshot",
+        "browser_click",
+        "browser_type",
+        "browser_execute_js",
+        "browser_close_tab",
+        "browser_screenshot",
+        "get_current_time",
+    },
+    "general": set(),  # special: all tasks except run_subagent
+}
+
+PROFILE_PROMPTS: dict[str, str] = {
+    "mail_research": (
+        "You are a mail research assistant. Search and read emails efficiently.\n"
+        "Summarize findings clearly. Use message IDs for precise lookups.\n"
+        "Check agent memory before searching to avoid duplicate work."
+    ),
+    "calendar_planner": (
+        "You are a calendar planning assistant. Work with events and reminders.\n"
+        "Be precise with dates, times, and time zones.\n"
+        "Cross-reference emails when relevant to calendar planning."
+    ),
+    "web_researcher": (
+        "You are a web research assistant. Search the web and extract information.\n"
+        "Prefer simple web_fetch/web_search over browser automation when possible.\n"
+        "Summarize findings concisely with source URLs."
+    ),
+    "general": (
+        "You are a general-purpose assistant with access to macOS automation tools.\n"
+        "Complete the task using the most appropriate tools available.\n"
+        "Be efficient and direct."
+    ),
+}
+
+
+@dataclass
+class SubagentResult:
+    """Result from a subagent execution."""
+
+    success: bool
+    response: str
+    profile: str
+    model: str
+    elapsed_seconds: float
+    iterations: int
+    input_tokens: int
+    output_tokens: int
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def resolve_model(config: Settings, tier: str) -> str:
+    """Resolve which model to use for the subagent.
+
+    Args:
+        config: Application settings.
+        tier: 'fast' for cheaper model, 'main' for same as parent.
+
+    Returns:
+        Model string in provider/model format.
+    """
+    if config.subagent_model:
+        return config.subagent_model
+
+    if tier == "fast":
+        provider = config.get_provider()
+        return PROVIDER_FAST_MODELS.get(provider, config.get_model())
+
+    return config.get_model()
+
+
+def create_scoped_registry(
+    parent_registry: TaskRegistry, profile: str
+) -> TaskRegistry:
+    """Create a new registry with only the tools allowed by the profile.
+
+    Args:
+        parent_registry: The parent agent's full registry.
+        profile: One of the PROFILE_TOOLS keys.
+
+    Returns:
+        A new TaskRegistry with scoped tasks.
+
+    Raises:
+        ValueError: If the profile is unknown.
+    """
+    if profile not in PROFILE_TOOLS:
+        raise ValueError(
+            f"Unknown subagent profile: {profile!r}. "
+            f"Valid profiles: {', '.join(PROFILE_TOOLS.keys())}"
+        )
+
+    registry = TaskRegistry()
+    allowed = PROFILE_TOOLS[profile]
+
+    for task in parent_registry.list_tasks():
+        if profile == "general":
+            # General: all tasks except run_subagent (no nesting)
+            if task.name != "run_subagent":
+                registry.register(task)
+        elif task.name in allowed:
+            registry.register(task)
+
+    return registry
+
+
+def build_subagent_prompt(profile: str) -> str:
+    """Build the system prompt for a subagent.
+
+    Args:
+        profile: The subagent profile name.
+
+    Returns:
+        System prompt string (system context is appended by Agent).
+    """
+    guidance = PROFILE_PROMPTS.get(profile, PROFILE_PROMPTS["general"])
+    return (
+        "You are a focused assistant performing a specific task.\n"
+        "Complete the task efficiently using available tools. "
+        "Return a clear summary when done.\n"
+        "Do not ask for confirmation — just execute.\n\n"
+        f"{guidance}"
+    )
+
+
+async def run_subagent(
+    config: Settings,
+    parent_registry: TaskRegistry,
+    goal: str,
+    profile: str = "general",
+    context: str = "",
+    tier: str = "fast",
+    on_event: Any | None = None,
+) -> SubagentResult:
+    """Run a subagent to completion.
+
+    Args:
+        config: Application settings.
+        parent_registry: The parent agent's task registry.
+        goal: The task for the subagent to accomplish.
+        profile: Tool profile (mail_research, calendar_planner, web_researcher, general).
+        context: Optional context to prepend to the goal.
+        tier: Model tier ('fast' or 'main').
+        on_event: Optional event callback for tool call/result events.
+
+    Returns:
+        SubagentResult with the outcome.
+    """
+    from macbot.core.agent import Agent
+    from macbot.providers.litellm_provider import LiteLLMProvider
+    from macbot.skills.registry import SkillsRegistry
+
+    model = resolve_model(config, tier)
+    start = time.monotonic()
+
+    try:
+        scoped_registry = create_scoped_registry(parent_registry, profile)
+
+        api_key = config.get_api_key_for_model(model)
+        api_base = config.get_api_base_for_model(model)
+        provider = LiteLLMProvider(model=model, api_key=api_key, api_base=api_base)
+
+        subagent_config = config.model_copy(
+            update={"max_iterations": config.subagent_max_iterations}
+        )
+
+        agent = Agent(
+            task_registry=scoped_registry,
+            provider=provider,
+            config=subagent_config,
+            skills_registry=SkillsRegistry(),  # empty — subagents don't use skills
+            system_prompt=build_subagent_prompt(profile),
+        )
+
+        # Build full goal with optional context
+        full_goal = goal
+        if context:
+            full_goal = f"Context:\n{context}\n\nTask:\n{goal}"
+
+        response = await asyncio.wait_for(
+            agent.run(full_goal, stream=False, on_event=on_event),
+            timeout=config.subagent_timeout,
+        )
+
+        stats = agent.get_token_stats()
+        elapsed = time.monotonic() - start
+
+        return SubagentResult(
+            success=True,
+            response=response,
+            profile=profile,
+            model=model,
+            elapsed_seconds=elapsed,
+            iterations=agent.iteration,
+            input_tokens=stats["session_input_tokens"],
+            output_tokens=stats["session_output_tokens"],
+        )
+
+    except TimeoutError:
+        elapsed = time.monotonic() - start
+        logger.warning(f"Subagent timed out after {elapsed:.1f}s (profile={profile})")
+        return SubagentResult(
+            success=False,
+            response=f"Subagent timed out after {config.subagent_timeout}s",
+            profile=profile,
+            model=model,
+            elapsed_seconds=elapsed,
+            iterations=0,
+            input_tokens=0,
+            output_tokens=0,
+        )
+
+    except Exception as e:
+        elapsed = time.monotonic() - start
+        logger.exception(f"Subagent failed (profile={profile})")
+        return SubagentResult(
+            success=False,
+            response=f"Subagent error: {e}",
+            profile=profile,
+            model=model,
+            elapsed_seconds=elapsed,
+            iterations=0,
+            input_tokens=0,
+            output_tokens=0,
+        )

--- a/src/macbot/tasks/__init__.py
+++ b/src/macbot/tasks/__init__.py
@@ -73,15 +73,19 @@ __all__ = [
 ]
 
 
-def create_default_registry() -> TaskRegistry:
+def create_default_registry(config: "Settings | None" = None) -> TaskRegistry:
     """Create a new task registry with all default tasks registered.
 
     This creates a fresh registry instance with all built-in tasks.
     Useful when you need an isolated registry.
 
+    Args:
+        config: Optional settings (subagent task uses this to configure itself).
+
     Returns:
         TaskRegistry with all default tasks.
     """
+    from macbot.config import Settings  # noqa: F811
     registry = TaskRegistry()
 
     # Import and register all built-in task classes
@@ -141,5 +145,9 @@ def create_default_registry() -> TaskRegistry:
     # Register core preferences task
     from macbot.tasks.preferences import register_preferences_tasks
     register_preferences_tasks(registry)
+
+    # Register subagent task (passes registry ref so subagents get scoped copies)
+    from macbot.tasks.subagent import RunSubagentTask
+    registry.register(RunSubagentTask(config=config, parent_registry=registry))
 
     return registry

--- a/src/macbot/tasks/subagent.py
+++ b/src/macbot/tasks/subagent.py
@@ -1,0 +1,86 @@
+"""Subagent task — exposes run_subagent as an LLM tool."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from macbot.config import settings
+from macbot.core.subagent import run_subagent
+from macbot.tasks.base import Task
+
+if TYPE_CHECKING:
+    from macbot.config import Settings
+    from macbot.tasks.registry import TaskRegistry
+
+
+class RunSubagentTask(Task):
+    """Delegate a focused task to a subagent with scoped tools."""
+
+    def __init__(
+        self,
+        config: Settings | None = None,
+        parent_registry: TaskRegistry | None = None,
+    ) -> None:
+        self._config = config
+        self._parent_registry = parent_registry
+
+    @property
+    def name(self) -> str:
+        return "run_subagent"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Delegate a focused task to a subagent that runs with its own context and tools.\n"
+            "Use this for multi-step research or actions that benefit from isolated focus.\n"
+            "\n"
+            "Profiles:\n"
+            "- mail_research: Email searching, reading, processing\n"
+            "- calendar_planner: Calendar events, reminders\n"
+            "- web_researcher: Web search, browsing, extraction\n"
+            "- general: All tools (for tasks that don't fit a specific profile)\n"
+            "\n"
+            "Tiers (model selection):\n"
+            "- fast: Cheaper/faster model (default, good for most delegated tasks)\n"
+            "- main: Same model as you (for tasks requiring high reasoning)"
+        )
+
+    async def execute(
+        self,
+        goal: str,
+        profile: str = "general",
+        context: str = "",
+        tier: str = "fast",
+    ) -> str:
+        """Run a subagent with the given parameters.
+
+        Args:
+            goal: The task for the subagent to accomplish.
+            profile: Tool profile (mail_research, calendar_planner, web_researcher, general).
+            context: Optional context to prepend to the goal.
+            tier: Model tier — 'fast' (cheaper) or 'main' (same as parent).
+
+        Returns:
+            Subagent response with metadata footer.
+        """
+        config = self._config or settings
+        registry = self._parent_registry
+        if registry is None:
+            from macbot.tasks import create_default_registry
+            registry = create_default_registry()
+
+        result = await run_subagent(
+            config=config,
+            parent_registry=registry,
+            goal=goal,
+            profile=profile,
+            context=context,
+            tier=tier,
+        )
+
+        footer = (
+            f"\n\n---\n[subagent: {result.profile}, model: {result.model}, "
+            f"{result.iterations} steps, {result.elapsed_seconds:.1f}s, "
+            f"{result.input_tokens + result.output_tokens} tokens]"
+        )
+        return result.response + footer

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -1,0 +1,283 @@
+"""Tests for the subagent system."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from macbot.config import Settings
+from macbot.core.subagent import (
+    PROFILE_PROMPTS,
+    PROFILE_TOOLS,
+    SubagentResult,
+    build_subagent_prompt,
+    create_scoped_registry,
+    resolve_model,
+    run_subagent,
+)
+from macbot.tasks.base import Task
+from macbot.tasks.registry import TaskRegistry
+from macbot.tasks.subagent import RunSubagentTask
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _DummyTask(Task):
+    """Minimal task for registry tests."""
+
+    def __init__(self, task_name: str) -> None:
+        self._name = task_name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return f"Dummy task: {self._name}"
+
+    async def execute(self, **kwargs) -> str:
+        return "ok"
+
+
+def _make_registry(names: list[str]) -> TaskRegistry:
+    """Build a registry with dummy tasks for the given names."""
+    reg = TaskRegistry()
+    for n in names:
+        reg.register(_DummyTask(n))
+    return reg
+
+
+def _make_settings(**overrides) -> Settings:
+    """Create a Settings instance with test defaults."""
+    defaults = {
+        "model": "anthropic/claude-sonnet-4-20250514",
+        "anthropic_api_key": "test-key",
+    }
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# resolve_model tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveModel:
+    def test_fast_anthropic(self) -> None:
+        config = _make_settings(model="anthropic/claude-sonnet-4-20250514")
+        assert resolve_model(config, "fast") == "anthropic/claude-haiku-4-5-20251001"
+
+    def test_fast_openai(self) -> None:
+        config = _make_settings(model="openai/gpt-4o")
+        assert resolve_model(config, "fast") == "openai/gpt-4o-mini"
+
+    def test_fast_pico_fallback(self) -> None:
+        """Pico is not in PROVIDER_FAST_MODELS → falls back to parent model."""
+        config = _make_settings(model="pico/llama3")
+        assert resolve_model(config, "fast") == "pico/llama3"
+
+    def test_main_tier(self) -> None:
+        config = _make_settings(model="anthropic/claude-sonnet-4-20250514")
+        assert resolve_model(config, "main") == "anthropic/claude-sonnet-4-20250514"
+
+    def test_config_override(self) -> None:
+        """subagent_model in config takes priority over tier logic."""
+        config = _make_settings(subagent_model="openai/gpt-4o")
+        assert resolve_model(config, "fast") == "openai/gpt-4o"
+        assert resolve_model(config, "main") == "openai/gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# create_scoped_registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateScopedRegistry:
+    def test_mail_profile(self) -> None:
+        all_names = list(PROFILE_TOOLS["mail_research"]) + ["run_subagent", "other_tool"]
+        parent = _make_registry(all_names)
+        scoped = create_scoped_registry(parent, "mail_research")
+
+        scoped_names = set(scoped.list_names())
+        assert scoped_names == PROFILE_TOOLS["mail_research"]
+        assert "run_subagent" not in scoped_names
+        assert "other_tool" not in scoped_names
+
+    def test_general_excludes_run_subagent(self) -> None:
+        parent = _make_registry(["get_current_time", "run_subagent", "search_emails"])
+        scoped = create_scoped_registry(parent, "general")
+
+        scoped_names = set(scoped.list_names())
+        assert "run_subagent" not in scoped_names
+        assert "get_current_time" in scoped_names
+        assert "search_emails" in scoped_names
+
+    def test_unknown_profile_raises(self) -> None:
+        parent = _make_registry(["get_current_time"])
+        with pytest.raises(ValueError, match="Unknown subagent profile"):
+            create_scoped_registry(parent, "nonexistent_profile")
+
+
+# ---------------------------------------------------------------------------
+# build_subagent_prompt tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSubagentPrompt:
+    def test_contains_profile_guidance(self) -> None:
+        for profile, guidance in PROFILE_PROMPTS.items():
+            prompt = build_subagent_prompt(profile)
+            assert guidance in prompt
+
+    def test_contains_base_instructions(self) -> None:
+        prompt = build_subagent_prompt("general")
+        assert "focused assistant" in prompt
+        assert "Do not ask for confirmation" in prompt
+
+
+# ---------------------------------------------------------------------------
+# RunSubagentTask schema test
+# ---------------------------------------------------------------------------
+
+
+class TestRunSubagentTaskSchema:
+    def test_tool_schema(self) -> None:
+        task = RunSubagentTask()
+        schema = task.to_tool_schema()
+
+        assert schema["name"] == "run_subagent"
+        props = schema["input_schema"]["properties"]
+        assert "goal" in props
+        assert "profile" in props
+        assert "context" in props
+        assert "tier" in props
+        assert len(props) == 4
+
+    def test_required_params(self) -> None:
+        task = RunSubagentTask()
+        schema = task.to_tool_schema()
+        assert schema["input_schema"]["required"] == ["goal"]
+
+
+# ---------------------------------------------------------------------------
+# Integration test with mock provider
+# ---------------------------------------------------------------------------
+
+
+class TestSubagentExecution:
+    @pytest.mark.asyncio
+    async def test_run_subagent_mock(self) -> None:
+        """Run a subagent with a mocked LLM provider that returns a canned response."""
+        config = _make_settings(subagent_max_iterations=5, subagent_timeout=10)
+        parent = _make_registry(["get_current_time", "search_emails", "run_subagent"])
+
+        mock_response = "Found 3 unread emails from today."
+
+        with patch("macbot.providers.litellm_provider.LiteLLMProvider"), \
+             patch("macbot.core.agent.Agent") as MockAgent:
+
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.run = AsyncMock(return_value=mock_response)
+            mock_agent_instance.iteration = 2
+            mock_agent_instance.get_token_stats.return_value = {
+                "session_input_tokens": 500,
+                "session_output_tokens": 100,
+                "session_total_tokens": 600,
+                "context_tokens": 0,
+                "message_count": 0,
+            }
+            MockAgent.return_value = mock_agent_instance
+
+            result = await run_subagent(
+                config=config,
+                parent_registry=parent,
+                goal="Find my unread emails",
+                profile="mail_research",
+                tier="fast",
+            )
+
+        assert isinstance(result, SubagentResult)
+        assert result.success is True
+        assert result.response == mock_response
+        assert result.profile == "mail_research"
+        assert result.model == "anthropic/claude-haiku-4-5-20251001"
+        assert result.iterations == 2
+        assert result.input_tokens == 500
+        assert result.output_tokens == 100
+        assert result.elapsed_seconds > 0
+
+    @pytest.mark.asyncio
+    async def test_run_subagent_timeout(self) -> None:
+        """Subagent timeout returns a failure result."""
+        import asyncio
+
+        config = _make_settings(subagent_max_iterations=5, subagent_timeout=1)
+        parent = _make_registry(["get_current_time"])
+
+        async def slow_run(*args, **kwargs):
+            await asyncio.sleep(10)
+            return "done"
+
+        with patch("macbot.providers.litellm_provider.LiteLLMProvider"), \
+             patch("macbot.core.agent.Agent") as MockAgent:
+
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.run = slow_run
+            MockAgent.return_value = mock_agent_instance
+
+            result = await run_subagent(
+                config=config,
+                parent_registry=parent,
+                goal="Do something slow",
+                profile="general",
+            )
+
+        assert result.success is False
+        assert "timed out" in result.response
+
+    @pytest.mark.asyncio
+    async def test_run_subagent_with_context(self) -> None:
+        """Context is prepended to the goal."""
+        config = _make_settings(subagent_max_iterations=5, subagent_timeout=10)
+        parent = _make_registry(["get_current_time"])
+
+        captured_goal = None
+
+        async def capture_run(goal, **kwargs):
+            nonlocal captured_goal
+            captured_goal = goal
+            return "done"
+
+        with patch("macbot.providers.litellm_provider.LiteLLMProvider"), \
+             patch("macbot.core.agent.Agent") as MockAgent:
+
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.run = capture_run
+            mock_agent_instance.iteration = 1
+            mock_agent_instance.get_token_stats.return_value = {
+                "session_input_tokens": 0,
+                "session_output_tokens": 0,
+                "session_total_tokens": 0,
+                "context_tokens": 0,
+                "message_count": 0,
+            }
+            MockAgent.return_value = mock_agent_instance
+
+            await run_subagent(
+                config=config,
+                parent_registry=parent,
+                goal="Find invoices",
+                context="User is looking for Medpex invoices from January",
+                profile="general",
+            )
+
+        assert captured_goal is not None
+        assert "Context:" in captured_goal
+        assert "Medpex invoices from January" in captured_goal
+        assert "Task:" in captured_goal
+        assert "Find invoices" in captured_goal


### PR DESCRIPTION
Introduces a run_subagent tool that lets the main agent delegate multi-step tasks (e.g. email research, calendar planning) to isolated child agents with scoped tool registries and optionally cheaper models. Subagents run to completion and return a summary — no nesting allowed.