### PR TITLE
Add end-to-end support for Telegram photo messages

### DIFF
--- a/app/src/lib/components/ChatPanel.svelte
+++ b/app/src/lib/components/ChatPanel.svelte
@@ -219,6 +219,16 @@
                   {/each}
                 </div>
               {/if}
+              <!-- Image attachment (shown above the text bubble) -->
+              {#if msg.imageUrl}
+                <div class="max-w-[85%]">
+                  <img
+                    src={msg.imageUrl}
+                    alt="Uploaded image"
+                    class="rounded-xl max-h-[240px] object-contain border border-border/30"
+                  />
+                </div>
+              {/if}
               <!-- Message bubble -->
               {#if msg.text || msg.status === "streaming"}
                 <div

--- a/app/src/lib/stores/chat.svelte.ts
+++ b/app/src/lib/stores/chat.svelte.ts
@@ -15,6 +15,7 @@ export interface ChatMessage {
   status: "streaming" | "complete" | "error";
   toolCalls?: ToolCall[];
   source?: "chat" | "telegram";
+  imageUrl?: string;
 }
 
 export interface AppPermissions {
@@ -227,6 +228,7 @@ class ChatStore {
         case "telegram_message": {
           const direction = msg.direction as string;
           const text = msg.text as string;
+          const imageUrl = msg.imageUrl as string | undefined;
           if (direction === "incoming") {
             // Incoming Telegram user message
             this._messages.push({
@@ -236,6 +238,7 @@ class ChatStore {
               text,
               status: "complete",
               source: "telegram",
+              imageUrl,
             });
             // Create placeholder for the assistant response (tool calls will attach here)
             this._telegramAssistantId = crypto.randomUUID();

--- a/src/macbot/core/agent.py
+++ b/src/macbot/core/agent.py
@@ -88,7 +88,7 @@ class Agent:
 
     async def run(
         self,
-        goal: str,
+        goal: str | list[dict[str, Any]],
         verbose: bool = False,
         stream: bool = True,
         continue_conversation: bool = False,
@@ -97,7 +97,8 @@ class Agent:
         """Run the agent loop to achieve a goal.
 
         Args:
-            goal: The objective for the agent to achieve
+            goal: The objective — a string for text, or a list of content
+                  blocks for multimodal input (e.g., text + image).
             verbose: Whether to print detailed output
             stream: Whether to stream LLM responses
             continue_conversation: If True, append to existing messages instead of resetting.
@@ -119,7 +120,8 @@ class Agent:
         self.iteration = 0
 
         if verbose:
-            console.print(Panel(f"[bold]Goal:[/bold] {goal}", title="Agent Started"))
+            goal_preview = goal if isinstance(goal, str) else Message(role="user", content=goal).content_text
+            console.print(Panel(f"[bold]Goal:[/bold] {goal_preview}", title="Agent Started"))
 
         while self.iteration < self.config.max_iterations:
             self.iteration += 1

--- a/src/macbot/providers/base.py
+++ b/src/macbot/providers/base.py
@@ -15,9 +15,26 @@ class Message(BaseModel):
     """A message in the conversation."""
 
     role: str  # "user", "assistant", "system", or "tool"
-    content: str | None = None
+    content: str | list[dict[str, Any]] | None = None  # str for text, list for multimodal content blocks
     tool_calls: list["ToolCall"] | None = None  # For assistant messages with tool calls
     tool_call_id: str | None = None  # For tool result messages
+
+    @property
+    def content_text(self) -> str:
+        """Extract the text portion of content for logging/display.
+
+        Returns the string as-is for str content, or extracts the first
+        text block from a content block list.
+        """
+        if isinstance(self.content, str):
+            return self.content
+        if isinstance(self.content, list):
+            for block in self.content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text", "")
+                    return str(text)
+            return ""
+        return ""
 
 
 class ToolCall(BaseModel):

--- a/src/macbot/providers/litellm_provider.py
+++ b/src/macbot/providers/litellm_provider.py
@@ -118,6 +118,8 @@ class LiteLLMProvider(LLMProvider):
                     "content": msg.content or "",
                 })
             else:
+                # Pass content as-is — LiteLLM/OpenAI natively support
+                # content block arrays for multimodal messages
                 litellm_messages.append({
                     "role": msg.role,
                     "content": msg.content,

--- a/src/macbot/providers/openai.py
+++ b/src/macbot/providers/openai.py
@@ -64,6 +64,8 @@ class OpenAIProvider(LLMProvider):
                     "content": msg.content or "",
                 })
             else:
+                # Pass content as-is — OpenAI natively supports
+                # content block arrays for multimodal messages
                 openai_messages.append({"role": msg.role, "content": msg.content})
 
         # Build request kwargs


### PR DESCRIPTION
Telegram photos are now downloaded, base64-encoded, and threaded as OpenAI-format content blocks through the full handler chain so the LLM can see and reason about images. The Anthropic provider converts them to its native base64 image format; LiteLLM and OpenAI pass them through natively.

The GUI chat panel displays uploaded images inline above the message bubble when received via Telegram.