### PR TITLE
Add account-based calendar disambiguation across all calendar tools

### DIFF
--- a/macos-automation/calendar/create-event.sh
+++ b/macos-automation/calendar/create-event.sh
@@ -4,15 +4,18 @@
 # ==============================================================================
 # Description:
 #   Creates a new event in the specified calendar with title, date/time,
-#   location, and optional description.
+#   location, and optional description. Supports account-based calendar
+#   disambiguation when multiple calendars share the same name.
 #
 # Usage:
 #   ./create-event.sh --calendar "Work" --title "Meeting" --start "2026-01-30 14:00" --end "2026-01-30 15:00"
+#   ./create-event.sh --account "Google" --calendar "Calendar" --title "Sync" --start "2026-02-03 10:00"
 #   ./create-event.sh --calendar "Work" --title "Holiday" --date "2026-02-14" --all-day
 #   ./create-event.sh --calendar "Work" --title "Standup" --start "2026-02-03 09:00" --duration 15
 #
 # Options:
 #   --calendar <name>    Calendar name (required)
+#   --account <name>     Account name to disambiguate calendars (optional)
 #   --title <text>       Event title (required)
 #   --start <datetime>   Start date/time as "YYYY-MM-DD HH:MM" (required unless --all-day)
 #   --end <datetime>     End date/time as "YYYY-MM-DD HH:MM"
@@ -23,7 +26,7 @@
 #   --notes <text>       Event description/notes (optional)
 #
 # Example:
-#   ./create-event.sh --calendar "Work" --title "Team Meeting" \
+#   ./create-event.sh --account "Google" --calendar "Calendar" --title "Team Meeting" \
 #       --start "2026-01-30 14:00" --end "2026-01-30 15:00" \
 #       --location "Conference Room A"
 # ==============================================================================
@@ -33,6 +36,7 @@ source "$SCRIPT_DIR/../lib/common.sh"
 
 # Default values
 CALENDAR=""
+ACCOUNT=""
 TITLE=""
 START=""
 END=""
@@ -47,6 +51,10 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --calendar)
             CALENDAR="$2"
+            shift 2
+            ;;
+        --account)
+            ACCOUNT="$2"
             shift 2
             ;;
         --title)
@@ -82,7 +90,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
-            head -35 "$0" | tail -30
+            head -39 "$0" | tail -34
             exit 0
             ;;
         *)
@@ -95,122 +103,146 @@ done
 [[ -z "$CALENDAR" ]] && error_exit "--calendar is required"
 [[ -z "$TITLE" ]] && error_exit "--title is required"
 
-# Escape special characters
-TITLE_ESCAPED=$(escape_for_applescript "$TITLE")
-LOCATION_ESCAPED=$(escape_for_applescript "$LOCATION")
-NOTES_ESCAPED=$(escape_for_applescript "$NOTES")
-
 if [[ "$ALL_DAY" == "true" ]]; then
     [[ -z "$DATE" ]] && error_exit "--date is required for all-day events"
-
-    # Parse the date components (locale-independent)
-    YEAR=$(date -j -f "%Y-%m-%d" "$DATE" "+%Y" 2>/dev/null)
-    MONTH=$(date -j -f "%Y-%m-%d" "$DATE" "+%-m" 2>/dev/null)
-    DAY=$(date -j -f "%Y-%m-%d" "$DATE" "+%-d" 2>/dev/null)
-    [[ -z "$YEAR" ]] && error_exit "Invalid date format. Use YYYY-MM-DD"
-
-    osascript <<EOF
-tell application "Calendar"
-    try
-        set targetCal to calendar "$CALENDAR"
-    on error
-        return "Error: Calendar '$CALENDAR' not found."
-    end try
-
-    -- Build date programmatically (locale-independent)
-    set startDate to current date
-    set year of startDate to $YEAR
-    set month of startDate to $MONTH
-    set day of startDate to $DAY
-    set hours of startDate to 0
-    set minutes of startDate to 0
-    set seconds of startDate to 0
-
-    tell targetCal
-        set newEvent to make new event with properties {summary:"$TITLE_ESCAPED", start date:startDate, allday event:true}
-
-        if "$LOCATION_ESCAPED" is not "" then
-            set location of newEvent to "$LOCATION_ESCAPED"
-        end if
-
-        if "$NOTES_ESCAPED" is not "" then
-            set description of newEvent to "$NOTES_ESCAPED"
-        end if
-    end tell
-
-    return "Created all-day event: $TITLE_ESCAPED on $DATE"
-end tell
-EOF
+    # Validate date format
+    date -j -f "%Y-%m-%d" "$DATE" "+%Y-%m-%d" >/dev/null 2>&1 || error_exit "Invalid date format. Use YYYY-MM-DD"
 else
     [[ -z "$START" ]] && error_exit "--start is required for timed events"
+    # Validate start format
+    date -j -f "%Y-%m-%d %H:%M" "$START" "+%s" >/dev/null 2>&1 || error_exit "Invalid start format. Use 'YYYY-MM-DD HH:MM'"
 
-    # Parse start date/time components (locale-independent)
-    START_YEAR=$(date -j -f "%Y-%m-%d %H:%M" "$START" "+%Y" 2>/dev/null)
-    START_MONTH=$(date -j -f "%Y-%m-%d %H:%M" "$START" "+%-m" 2>/dev/null)
-    START_DAY=$(date -j -f "%Y-%m-%d %H:%M" "$START" "+%-d" 2>/dev/null)
-    START_HOUR=$(date -j -f "%Y-%m-%d %H:%M" "$START" "+%-H" 2>/dev/null)
-    START_MIN=$(date -j -f "%Y-%m-%d %H:%M" "$START" "+%-M" 2>/dev/null)
-    [[ -z "$START_YEAR" ]] && error_exit "Invalid start format. Use 'YYYY-MM-DD HH:MM'"
-
-    # Calculate end time
-    if [[ -n "$DURATION" ]]; then
-        # Calculate end from duration
-        START_EPOCH=$(date -j -f "%Y-%m-%d %H:%M" "$START" "+%s" 2>/dev/null)
-        END_EPOCH=$((START_EPOCH + DURATION * 60))
-    elif [[ -n "$END" ]]; then
-        END_EPOCH=$(date -j -f "%Y-%m-%d %H:%M" "$END" "+%s" 2>/dev/null)
-        [[ -z "$END_EPOCH" ]] && error_exit "Invalid end format. Use 'YYYY-MM-DD HH:MM'"
+    # Calculate end time if not provided
+    if [[ -z "$END" ]]; then
+        START_EPOCH=$(date -j -f "%Y-%m-%d %H:%M" "$START" "+%s")
+        if [[ -n "$DURATION" ]]; then
+            END_EPOCH=$((START_EPOCH + DURATION * 60))
+        else
+            # Default to 1 hour duration
+            END_EPOCH=$((START_EPOCH + 3600))
+        fi
+        END=$(date -j -f "%s" "$END_EPOCH" "+%Y-%m-%d %H:%M")
     else
-        # Default to 1 hour duration
-        START_EPOCH=$(date -j -f "%Y-%m-%d %H:%M" "$START" "+%s" 2>/dev/null)
-        END_EPOCH=$((START_EPOCH + 3600))
+        date -j -f "%Y-%m-%d %H:%M" "$END" "+%s" >/dev/null 2>&1 || error_exit "Invalid end format. Use 'YYYY-MM-DD HH:MM'"
     fi
-
-    END_YEAR=$(date -j -f "%s" "$END_EPOCH" "+%Y" 2>/dev/null)
-    END_MONTH=$(date -j -f "%s" "$END_EPOCH" "+%-m" 2>/dev/null)
-    END_DAY=$(date -j -f "%s" "$END_EPOCH" "+%-d" 2>/dev/null)
-    END_HOUR=$(date -j -f "%s" "$END_EPOCH" "+%-H" 2>/dev/null)
-    END_MIN=$(date -j -f "%s" "$END_EPOCH" "+%-M" 2>/dev/null)
-
-    osascript <<EOF
-tell application "Calendar"
-    try
-        set targetCal to calendar "$CALENDAR"
-    on error
-        return "Error: Calendar '$CALENDAR' not found."
-    end try
-
-    -- Build start date programmatically (locale-independent)
-    set startDate to current date
-    set year of startDate to $START_YEAR
-    set month of startDate to $START_MONTH
-    set day of startDate to $START_DAY
-    set hours of startDate to $START_HOUR
-    set minutes of startDate to $START_MIN
-    set seconds of startDate to 0
-
-    -- Build end date programmatically (locale-independent)
-    set endDate to current date
-    set year of endDate to $END_YEAR
-    set month of endDate to $END_MONTH
-    set day of endDate to $END_DAY
-    set hours of endDate to $END_HOUR
-    set minutes of endDate to $END_MIN
-    set seconds of endDate to 0
-
-    tell targetCal
-        set newEvent to make new event with properties {summary:"$TITLE_ESCAPED", start date:startDate, end date:endDate}
-
-        if "$LOCATION_ESCAPED" is not "" then
-            set location of newEvent to "$LOCATION_ESCAPED"
-        end if
-
-        if "$NOTES_ESCAPED" is not "" then
-            set description of newEvent to "$NOTES_ESCAPED"
-        end if
-    end tell
-
-    return "Created event: $TITLE_ESCAPED on $START"
-end tell
-EOF
 fi
+
+# Escape double quotes and backslashes for Swift string literals
+escape_for_swift() {
+    local str="$1"
+    str="${str//\\/\\\\}"
+    str="${str//\"/\\\"}"
+    echo "$str"
+}
+
+TITLE_ESC=$(escape_for_swift "$TITLE")
+LOCATION_ESC=$(escape_for_swift "$LOCATION")
+NOTES_ESC=$(escape_for_swift "$NOTES")
+CALENDAR_ESC=$(escape_for_swift "$CALENDAR")
+ACCOUNT_ESC=$(escape_for_swift "$ACCOUNT")
+
+# Use Swift with EventKit for account-aware calendar lookup
+swift -e '
+import EventKit
+import Foundation
+
+let calendarName = "'"$CALENDAR_ESC"'"
+let accountFilter = "'"$ACCOUNT_ESC"'"
+let eventTitle = "'"$TITLE_ESC"'"
+let locationStr = "'"$LOCATION_ESC"'"
+let notesStr = "'"$NOTES_ESC"'"
+let isAllDayEvent = '"$( [[ "$ALL_DAY" == "true" ]] && echo "true" || echo "false" )"'
+let dateStr = "'"$DATE"'"
+let startStr = "'"$START"'"
+let endStr = "'"$END"'"
+let store = EKEventStore()
+let semaphore = DispatchSemaphore(value: 0)
+
+store.requestFullAccessToEvents { granted, error in
+    defer { semaphore.signal() }
+
+    guard granted else {
+        print("Error: Calendar access denied. Please grant access in System Settings > Privacy & Security > Calendars.")
+        return
+    }
+
+    // Find the target calendar
+    let allCalendars = store.calendars(for: .event)
+    let matching: [EKCalendar]
+
+    if !accountFilter.isEmpty {
+        matching = allCalendars.filter {
+            $0.title == calendarName &&
+            $0.source.title.localizedCaseInsensitiveContains(accountFilter)
+        }
+    } else {
+        matching = allCalendars.filter { $0.title == calendarName }
+    }
+
+    guard let targetCalendar = matching.first else {
+        if !accountFilter.isEmpty {
+            print("Error: Calendar \"\(calendarName)\" not found in account \"\(accountFilter)\".")
+        } else {
+            print("Error: Calendar \"\(calendarName)\" not found.")
+        }
+        return
+    }
+
+    guard targetCalendar.allowsContentModifications else {
+        print("Error: Calendar \"\(calendarName)\" is read-only.")
+        return
+    }
+
+    // Create the event
+    let event = EKEvent(eventStore: store)
+    event.calendar = targetCalendar
+    event.title = eventTitle
+
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+
+    if isAllDayEvent {
+        formatter.dateFormat = "yyyy-MM-dd"
+        guard let date = formatter.date(from: dateStr) else {
+            print("Error: Invalid date format.")
+            return
+        }
+        event.startDate = date
+        event.endDate = Calendar.current.date(byAdding: .day, value: 1, to: date)!
+        event.isAllDay = true
+    } else {
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        guard let start = formatter.date(from: startStr) else {
+            print("Error: Invalid start datetime format.")
+            return
+        }
+        guard let end = formatter.date(from: endStr) else {
+            print("Error: Invalid end datetime format.")
+            return
+        }
+        event.startDate = start
+        event.endDate = end
+    }
+
+    if !locationStr.isEmpty {
+        event.location = locationStr
+    }
+    if !notesStr.isEmpty {
+        event.notes = notesStr
+    }
+
+    do {
+        try store.save(event, span: .thisEvent)
+        let calInfo = !accountFilter.isEmpty ? "\(calendarName) (\(targetCalendar.source.title))" : calendarName
+        if isAllDayEvent {
+            print("Created all-day event: \(eventTitle) on \(dateStr) in \(calInfo)")
+        } else {
+            print("Created event: \(eventTitle) on \(startStr) in \(calInfo)")
+        }
+    } catch {
+        print("Error creating event: \(error.localizedDescription)")
+    }
+}
+
+semaphore.wait()
+' 2>&1

--- a/src/macbot/tasks/macos_automation.py
+++ b/src/macbot/tasks/macos_automation.py
@@ -452,16 +452,25 @@ class GetTodayEventsTask(Task):
     def description(self) -> str:
         return "Get all calendar events scheduled for today from Calendar.app."
 
-    async def execute(self, calendar: str | None = None) -> dict[str, Any]:
+    async def execute(
+        self,
+        calendar: str | None = None,
+        account: str | None = None,
+    ) -> dict[str, Any]:
         """Get today's events.
 
         Args:
             calendar: Only show events from this calendar (optional).
+            account: Only show events from calendars in this account (optional).
 
         Returns:
             Dictionary with today's events.
         """
-        args = ["--calendar", calendar] if calendar else []
+        args: list[str] = []
+        if calendar:
+            args.extend(["--calendar", calendar])
+        if account:
+            args.extend(["--account", account])
         return await run_script("calendar/get-today-events.sh", args)
 
 
@@ -479,13 +488,15 @@ class GetWeekEventsTask(Task):
     async def execute(
         self,
         days: int = 7,
-        calendar: str | None = None
+        calendar: str | None = None,
+        account: str | None = None,
     ) -> dict[str, Any]:
         """Get upcoming events.
 
         Args:
             days: Number of days to look ahead (default: 7).
             calendar: Only show events from this calendar (optional).
+            account: Only show events from calendars in this account (optional).
 
         Returns:
             Dictionary with upcoming events.
@@ -493,6 +504,8 @@ class GetWeekEventsTask(Task):
         args = ["--days", str(days)]
         if calendar:
             args.extend(["--calendar", calendar])
+        if account:
+            args.extend(["--account", account])
         return await run_script("calendar/get-week-events.sh", args)
 
 
@@ -517,7 +530,8 @@ class CreateCalendarEventTask(Task):
         date: str | None = None,
         all_day: bool = False,
         location: str | None = None,
-        notes: str | None = None
+        notes: str | None = None,
+        account: str | None = None,
     ) -> dict[str, Any]:
         """Create a calendar event.
 
@@ -531,11 +545,15 @@ class CreateCalendarEventTask(Task):
             all_day: Create an all-day event.
             location: Event location (optional).
             notes: Event description/notes (optional).
+            account: Account name to disambiguate calendars with the same name (optional).
 
         Returns:
             Dictionary with creation result.
         """
         args = ["--calendar", calendar, "--title", title]
+
+        if account:
+            args.extend(["--account", account])
 
         if all_day:
             if not date:
@@ -559,7 +577,7 @@ class CreateCalendarEventTask(Task):
 
 
 class ListCalendarsTask(Task):
-    """List all available calendars."""
+    """List all available calendars grouped by account."""
 
     @property
     def name(self) -> str:
@@ -567,18 +585,27 @@ class ListCalendarsTask(Task):
 
     @property
     def description(self) -> str:
-        return "List all calendars available in Calendar.app."
+        return "List all calendars available in Calendar.app, grouped by account."
 
-    async def execute(self, with_counts: bool = False) -> dict[str, Any]:
+    async def execute(
+        self,
+        with_counts: bool = False,
+        account: str | None = None,
+    ) -> dict[str, Any]:
         """List calendars.
 
         Args:
             with_counts: Include event counts for each calendar.
+            account: Only show calendars from this account (optional).
 
         Returns:
-            Dictionary with calendar list.
+            Dictionary with calendar list grouped by account.
         """
-        args = ["--with-counts"] if with_counts else []
+        args: list[str] = []
+        if with_counts:
+            args.append("--with-counts")
+        if account:
+            args.extend(["--account", account])
         return await run_script("calendar/list-calendars.sh", args)
 
 


### PR DESCRIPTION
Calendar listing now uses EventKit (instead of AppleScript) to group calendars by account, so the agent can distinguish between identically named calendars across different accounts (e.g. multiple "Calendar" entries). All calendar scripts and Python tasks accept an optional --account / account parameter for filtering and targeting.