### PR TITLE
Add folder access permission check for Documents, Downloads, Desktop

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "son-of-simon"
-version = "0.4.2"
+version = "0.4.6"
 dependencies = [
  "dirs 5.0.1",
  "macos-accessibility-client",

--- a/app/src/lib/stores/onboarding.svelte.ts
+++ b/app/src/lib/stores/onboarding.svelte.ts
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 export interface PermissionsData {
   accessibility: boolean;
   automation: Record<string, boolean>;
+  folder_access: Record<string, boolean>;
 }
 
 export interface ApiKeyData {
@@ -76,6 +77,11 @@ function createDefaultState(): OnboardingState {
           Reminders: false,
           Notes: false,
           Safari: false,
+        },
+        folder_access: {
+          Documents: false,
+          Downloads: false,
+          Desktop: false,
         },
       },
       api_key: {

--- a/src/macbot/cli.py
+++ b/src/macbot/cli.py
@@ -1681,6 +1681,32 @@ def cmd_doctor(args: argparse.Namespace) -> None:
     check("Safari.app", ok, msg,
           "Grant access in System Settings > Privacy & Security > Automation" if not ok else None)
 
+    # Folder Access
+    if not json_mode:
+        console.print("\n[bold]Folder Access[/bold]")
+
+    results["permissions"]["folder_access"] = {}
+    home_dir = Path.home()
+    for folder_name in ["Documents", "Downloads", "Desktop"]:
+        folder_path = home_dir / folder_name
+        try:
+            os.listdir(folder_path)
+            accessible = True
+            msg = str(folder_path)
+        except PermissionError:
+            accessible = False
+            msg = "Permission denied"
+        except FileNotFoundError:
+            accessible = False
+            msg = "Folder not found"
+        except Exception as e:
+            accessible = False
+            msg = str(e)[:60]
+
+        results["permissions"]["folder_access"][folder_name] = accessible
+        check(f"~/{folder_name}", accessible, msg,
+              "Grant access in System Settings > Privacy & Security > Files and Folders" if not accessible else None)
+
     # Browser Automation Tools
     if not json_mode:
         console.print("\n[bold]Browser Automation[/bold]")


### PR DESCRIPTION
macOS TCC protects user folders, and without checking access upfront users hit cryptic failures when the app tries to download attachments, run Spotlight searches, or manage files. This adds folder access checks to the onboarding UI (Step 3) and the `son doctor` CLI command.