### PR TITLE
Add Contacts, Messages, and System Controls automation

### DIFF
--- a/macos-automation/contacts/create-contact.sh
+++ b/macos-automation/contacts/create-contact.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# ==============================================================================
+# create-contact.sh - Create a new contact in Contacts.app
+# ==============================================================================
+# Description:
+#   Creates a new contact with the specified properties. Supports multiple
+#   email addresses and phone numbers. Can optionally add the contact to
+#   an existing group.
+#
+# Usage:
+#   ./create-contact.sh --first-name "John"
+#   ./create-contact.sh --first-name "John" --last-name "Smith" --email "john@example.com"
+#   ./create-contact.sh --first-name "Jane" --email "jane@work.com" --email "jane@home.com"
+#   ./create-contact.sh --first-name "Bob" --phone "+1-555-1234" --organization "Acme Inc"
+#
+# Options:
+#   --first-name <text>      First name (required)
+#   --last-name <text>       Last name
+#   --email <address>        Email address (can be specified multiple times)
+#   --phone <number>         Phone number (can be specified multiple times)
+#   --organization <text>    Company/organization name
+#   --job-title <text>       Job title
+#   --group <name>           Add to existing group (error if group not found)
+#
+# Example:
+#   ./create-contact.sh --first-name "John" --last-name "Doe" --email "john@example.com" --phone "+1-555-0123" --organization "Acme Inc" --group "Work"
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+FIRST_NAME=""
+LAST_NAME=""
+EMAILS=()
+PHONES=()
+ORGANIZATION=""
+JOB_TITLE=""
+GROUP=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --first-name)
+            FIRST_NAME="$2"
+            shift 2
+            ;;
+        --last-name)
+            LAST_NAME="$2"
+            shift 2
+            ;;
+        --email)
+            EMAILS+=("$2")
+            shift 2
+            ;;
+        --phone)
+            PHONES+=("$2")
+            shift 2
+            ;;
+        --organization)
+            ORGANIZATION="$2"
+            shift 2
+            ;;
+        --job-title)
+            JOB_TITLE="$2"
+            shift 2
+            ;;
+        --group)
+            GROUP="$2"
+            shift 2
+            ;;
+        -h|--help)
+            head -27 "$0" | tail -26
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Validate
+[[ -z "$FIRST_NAME" ]] && error_exit "--first-name is required"
+
+# Escape for AppleScript
+FIRST_NAME_ESCAPED=$(escape_for_applescript "$FIRST_NAME")
+LAST_NAME_ESCAPED=$(escape_for_applescript "$LAST_NAME")
+ORG_ESCAPED=$(escape_for_applescript "$ORGANIZATION")
+JOB_TITLE_ESCAPED=$(escape_for_applescript "$JOB_TITLE")
+GROUP_ESCAPED=$(escape_for_applescript "$GROUP")
+
+# Build properties string
+PROPS="first name:\"$FIRST_NAME_ESCAPED\""
+
+if [[ -n "$LAST_NAME" ]]; then
+    PROPS="$PROPS, last name:\"$LAST_NAME_ESCAPED\""
+fi
+
+if [[ -n "$ORGANIZATION" ]]; then
+    PROPS="$PROPS, organization:\"$ORG_ESCAPED\""
+fi
+
+if [[ -n "$JOB_TITLE" ]]; then
+    PROPS="$PROPS, job title:\"$JOB_TITLE_ESCAPED\""
+fi
+
+# Build AppleScript for adding emails
+ADD_EMAILS=""
+for email in "${EMAILS[@]}"; do
+    email_escaped=$(escape_for_applescript "$email")
+    ADD_EMAILS="$ADD_EMAILS
+        make new email at end of emails of newPerson with properties {label:\"work\", value:\"$email_escaped\"}"
+done
+
+# Build AppleScript for adding phones
+ADD_PHONES=""
+for phone in "${PHONES[@]}"; do
+    phone_escaped=$(escape_for_applescript "$phone")
+    ADD_PHONES="$ADD_PHONES
+        make new phone at end of phones of newPerson with properties {label:\"mobile\", value:\"$phone_escaped\"}"
+done
+
+osascript <<EOF
+tell application "Contacts"
+    -- If group specified, verify it exists first
+    if "$GROUP_ESCAPED" is not "" then
+        try
+            set targetGroup to group "$GROUP_ESCAPED"
+        on error
+            -- List available groups for helpful error message
+            set groupNames to name of every group
+            set AppleScript's text item delimiters to ", "
+            set groupList to groupNames as text
+            return "Error: Group '$GROUP_ESCAPED' not found. Available groups: " & groupList
+        end try
+    end if
+
+    -- Create the contact
+    set newPerson to make new person with properties {$PROPS}
+
+    -- Add emails
+    $ADD_EMAILS
+
+    -- Add phones
+    $ADD_PHONES
+
+    -- Save changes
+    save
+
+    -- Add to group if specified
+    if "$GROUP_ESCAPED" is not "" then
+        add newPerson to group "$GROUP_ESCAPED"
+        save
+    end if
+
+    -- Build confirmation output
+    set output to "Created contact: " & name of newPerson & return
+    set output to output & "ID: " & id of newPerson & return
+
+    if (count of emails of newPerson) > 0 then
+        repeat with e in emails of newPerson
+            set output to output & "Email: " & value of e & return
+        end repeat
+    end if
+
+    if (count of phones of newPerson) > 0 then
+        repeat with ph in phones of newPerson
+            set output to output & "Phone: " & value of ph & return
+        end repeat
+    end if
+
+    if "$ORG_ESCAPED" is not "" then
+        set output to output & "Organization: $ORG_ESCAPED" & return
+    end if
+
+    if "$JOB_TITLE_ESCAPED" is not "" then
+        set output to output & "Job Title: $JOB_TITLE_ESCAPED" & return
+    end if
+
+    if "$GROUP_ESCAPED" is not "" then
+        set output to output & "Group: $GROUP_ESCAPED" & return
+    end if
+
+    return output
+end tell
+EOF

--- a/macos-automation/contacts/get-contact.sh
+++ b/macos-automation/contacts/get-contact.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+# ==============================================================================
+# get-contact.sh - Get full contact card details
+# ==============================================================================
+# Description:
+#   Retrieves the full contact card for a person by name or Contacts ID.
+#   Returns all available fields: names, emails, phones, addresses,
+#   organization, job title, birthday, notes, and group memberships.
+#
+# Usage:
+#   ./get-contact.sh --name "John Smith"
+#   ./get-contact.sh --name "Smith" --exact
+#   ./get-contact.sh --id "ABC123-DEF456"
+#
+# Options:
+#   --name <text>    Search by contact name (contains match by default)
+#   --id <id>        Look up by Contacts ID (exact match)
+#   --exact          Use exact name match instead of contains
+#
+# Example:
+#   ./get-contact.sh --name "John Smith" --exact
+#   ./get-contact.sh --name "Smith"
+#   ./get-contact.sh --id "1A2B3C4D-5E6F-7890-ABCD-EF1234567890:ABPerson"
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+NAME=""
+CONTACT_ID=""
+EXACT=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --name)
+            NAME="$2"
+            shift 2
+            ;;
+        --id)
+            CONTACT_ID="$2"
+            shift 2
+            ;;
+        --exact)
+            EXACT=true
+            shift
+            ;;
+        -h|--help)
+            head -24 "$0" | tail -23
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Validate
+if [[ -z "$NAME" && -z "$CONTACT_ID" ]]; then
+    error_exit "Please specify --name or --id"
+fi
+
+# Escape for AppleScript
+NAME_ESCAPED=$(escape_for_applescript "$NAME")
+ID_ESCAPED=$(escape_for_applescript "$CONTACT_ID")
+
+osascript <<EOF
+tell application "Contacts"
+    set matchedPeople to {}
+
+    if "$ID_ESCAPED" is not "" then
+        -- Look up by ID
+        try
+            set matchedPeople to {person id "$ID_ESCAPED"}
+        on error
+            return "No contact found with ID: $ID_ESCAPED"
+        end try
+    else if $EXACT then
+        set matchedPeople to (every person whose name is "$NAME_ESCAPED")
+    else
+        set matchedPeople to (every person whose name contains "$NAME_ESCAPED")
+    end if
+
+    if (count of matchedPeople) is 0 then
+        return "No contact found matching criteria."
+    end if
+
+    set output to ""
+
+    repeat with p in matchedPeople
+        set output to output & "=== CONTACT CARD ===" & return & return
+
+        -- ID
+        set output to output & "ID: " & id of p & return
+
+        -- Names
+        try
+            set fn to first name of p
+            if fn is not missing value then
+                set output to output & "First Name: " & fn & return
+            end if
+        end try
+        try
+            set ln to last name of p
+            if ln is not missing value then
+                set output to output & "Last Name: " & ln & return
+            end if
+        end try
+        set output to output & "Full Name: " & name of p & return
+
+        -- Organization and Job Title
+        try
+            set org to organization of p
+            if org is not missing value and org is not "" then
+                set output to output & "Organization: " & org & return
+            end if
+        end try
+        try
+            set jt to job title of p
+            if jt is not missing value and jt is not "" then
+                set output to output & "Job Title: " & jt & return
+            end if
+        end try
+
+        -- Emails with labels
+        try
+            set emailList to emails of p
+            if (count of emailList) > 0 then
+                set output to output & return & "Emails:" & return
+                repeat with e in emailList
+                    set eLabel to label of e
+                    set eValue to value of e
+                    -- Clean up label (remove _$!<>!$_ wrapping)
+                    set cleanLabel to do shell script "echo " & quoted form of eLabel & " | sed 's/_\\$!<//;s/>!\\$_//'"
+                    set output to output & "  " & cleanLabel & ": " & eValue & return
+                end repeat
+            end if
+        end try
+
+        -- Phones with labels
+        try
+            set phoneList to phones of p
+            if (count of phoneList) > 0 then
+                set output to output & return & "Phones:" & return
+                repeat with ph in phoneList
+                    set phLabel to label of ph
+                    set phValue to value of ph
+                    set cleanLabel to do shell script "echo " & quoted form of phLabel & " | sed 's/_\\$!<//;s/>!\\$_//'"
+                    set output to output & "  " & cleanLabel & ": " & phValue & return
+                end repeat
+            end if
+        end try
+
+        -- Addresses with labels
+        try
+            set addrList to addresses of p
+            if (count of addrList) > 0 then
+                set output to output & return & "Addresses:" & return
+                repeat with a in addrList
+                    set aLabel to label of a
+                    set cleanLabel to do shell script "echo " & quoted form of aLabel & " | sed 's/_\\$!<//;s/>!\\$_//'"
+                    set output to output & "  " & cleanLabel & ":" & return
+                    try
+                        set s to street of a
+                        if s is not missing value and s is not "" then
+                            set output to output & "    Street: " & s & return
+                        end if
+                    end try
+                    try
+                        set c to city of a
+                        if c is not missing value and c is not "" then
+                            set output to output & "    City: " & c & return
+                        end if
+                    end try
+                    try
+                        set st to state of a
+                        if st is not missing value and st is not "" then
+                            set output to output & "    State: " & st & return
+                        end if
+                    end try
+                    try
+                        set z to zip of a
+                        if z is not missing value and z is not "" then
+                            set output to output & "    ZIP: " & z & return
+                        end if
+                    end try
+                    try
+                        set co to country of a
+                        if co is not missing value and co is not "" then
+                            set output to output & "    Country: " & co & return
+                        end if
+                    end try
+                end repeat
+            end if
+        end try
+
+        -- Birthday
+        try
+            set bday to birth date of p
+            if bday is not missing value then
+                set output to output & return & "Birthday: " & (bday as string) & return
+            end if
+        end try
+
+        -- Notes
+        try
+            set n to note of p
+            if n is not missing value and n is not "" then
+                set output to output & return & "Notes: " & n & return
+            end if
+        end try
+
+        -- Groups
+        try
+            set groupList to groups of p
+            if (count of groupList) > 0 then
+                set output to output & return & "Groups:" & return
+                repeat with g in groupList
+                    set output to output & "  - " & name of g & return
+                end repeat
+            end if
+        end try
+
+        set output to output & return
+    end repeat
+
+    if (count of matchedPeople) > 1 then
+        set output to output & "Found " & (count of matchedPeople) & " matching contacts." & return
+    end if
+
+    return output
+end tell
+EOF

--- a/macos-automation/contacts/list-groups.sh
+++ b/macos-automation/contacts/list-groups.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# ==============================================================================
+# list-groups.sh - List all contact groups
+# ==============================================================================
+# Description:
+#   Lists all contact groups in Contacts.app with member counts. Optionally
+#   shows the names of members in each group.
+#
+# Usage:
+#   ./list-groups.sh
+#   ./list-groups.sh --with-members
+#   ./list-groups.sh --with-members --limit 10
+#
+# Options:
+#   --with-members   Show member names under each group
+#   --limit <n>      Limit number of groups displayed (default: 50)
+#
+# Example:
+#   ./list-groups.sh
+#   ./list-groups.sh --with-members --limit 25
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+WITH_MEMBERS=false
+LIMIT=50
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --with-members)
+            WITH_MEMBERS=true
+            shift
+            ;;
+        --limit)
+            LIMIT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            head -21 "$0" | tail -20
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+osascript <<EOF
+tell application "Contacts"
+    set allGroups to every group
+    set totalGroups to count of allGroups
+
+    if totalGroups is 0 then
+        return "No contact groups found."
+    end if
+
+    -- Cap at limit
+    if totalGroups > $LIMIT then
+        set displayCount to $LIMIT
+    else
+        set displayCount to totalGroups
+    end if
+
+    set output to "=== CONTACT GROUPS ===" & return & return
+
+    repeat with i from 1 to displayCount
+        set g to item i of allGroups
+        set gName to name of g
+        set memberList to every person of g
+        set memberCount to count of memberList
+
+        set output to output & gName & " (" & memberCount & " members)" & return
+
+        if $WITH_MEMBERS and memberCount > 0 then
+            -- Bulk-fetch names for performance
+            set memberNames to name of every person of g
+            repeat with mName in memberNames
+                set output to output & "  - " & mName & return
+            end repeat
+            set output to output & return
+        end if
+    end repeat
+
+    set output to output & return & "Total: " & totalGroups & " group(s)"
+    if totalGroups > $LIMIT then
+        set output to output & " (showing " & displayCount & ")"
+    end if
+
+    return output
+end tell
+EOF

--- a/macos-automation/contacts/search-contacts.sh
+++ b/macos-automation/contacts/search-contacts.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+# ==============================================================================
+# search-contacts.sh - Search contacts by name, email, phone, or organization
+# ==============================================================================
+# Description:
+#   Searches contacts in Contacts.app matching specified criteria. Uses fast
+#   'whose' clause for name and organization lookups. For email and phone,
+#   iterates all people since Contacts.app doesn't support 'whose' on
+#   multi-value properties reliably.
+#
+# Usage:
+#   ./search-contacts.sh --name "John"
+#   ./search-contacts.sh --email "example.com"
+#   ./search-contacts.sh --phone "555"
+#   ./search-contacts.sh --organization "Acme" --limit 10
+#
+# Options:
+#   --name <pattern>          Search by contact name (contains match)
+#   --email <pattern>         Search by email address (contains match)
+#   --phone <pattern>         Search by phone number (contains match)
+#   --organization <pattern>  Search by organization name (contains match)
+#   --limit <n>               Limit results (default: 20)
+#
+# Example:
+#   ./search-contacts.sh --name "Smith"
+#   ./search-contacts.sh --email "@gmail.com" --limit 50
+#   ./search-contacts.sh --organization "Apple" --name "John"
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+NAME_PATTERN=""
+EMAIL_PATTERN=""
+PHONE_PATTERN=""
+ORG_PATTERN=""
+LIMIT=20
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --name)
+            NAME_PATTERN="$2"
+            shift 2
+            ;;
+        --email)
+            EMAIL_PATTERN="$2"
+            shift 2
+            ;;
+        --phone)
+            PHONE_PATTERN="$2"
+            shift 2
+            ;;
+        --organization)
+            ORG_PATTERN="$2"
+            shift 2
+            ;;
+        --limit)
+            LIMIT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            head -28 "$0" | tail -27
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Validate - at least one search criterion required
+if [[ -z "$NAME_PATTERN" && -z "$EMAIL_PATTERN" && -z "$PHONE_PATTERN" && -z "$ORG_PATTERN" ]]; then
+    error_exit "At least one search criterion required: --name, --email, --phone, or --organization"
+fi
+
+# Escape for AppleScript
+NAME_ESCAPED=$(escape_for_applescript "$NAME_PATTERN")
+EMAIL_ESCAPED=$(escape_for_applescript "$EMAIL_PATTERN")
+PHONE_ESCAPED=$(escape_for_applescript "$PHONE_PATTERN")
+ORG_ESCAPED=$(escape_for_applescript "$ORG_PATTERN")
+
+osascript <<EOF
+tell application "Contacts"
+    set matchedPeople to {}
+
+    -- Determine search strategy based on criteria
+    -- Name and organization support fast 'whose' clause
+    -- Email and phone require iteration over multi-value properties
+
+    if "$EMAIL_ESCAPED" is not "" or "$PHONE_ESCAPED" is not "" then
+        -- Need to iterate: get candidate set first
+        if "$NAME_ESCAPED" is not "" and "$ORG_ESCAPED" is not "" then
+            set candidates to (every person whose name contains "$NAME_ESCAPED" and organization contains "$ORG_ESCAPED")
+        else if "$NAME_ESCAPED" is not "" then
+            set candidates to (every person whose name contains "$NAME_ESCAPED")
+        else if "$ORG_ESCAPED" is not "" then
+            set candidates to (every person whose organization contains "$ORG_ESCAPED")
+        else
+            set candidates to every person
+        end if
+
+        repeat with p in candidates
+            if (count of matchedPeople) >= $LIMIT then exit repeat
+
+            set includeContact to true
+
+            -- Filter by email
+            if "$EMAIL_ESCAPED" is not "" then
+                set emailMatch to false
+                try
+                    set emailList to value of emails of p
+                    repeat with e in emailList
+                        if e contains "$EMAIL_ESCAPED" then
+                            set emailMatch to true
+                            exit repeat
+                        end if
+                    end repeat
+                end try
+                if not emailMatch then set includeContact to false
+            end if
+
+            -- Filter by phone
+            if includeContact and "$PHONE_ESCAPED" is not "" then
+                set phoneMatch to false
+                try
+                    set phoneList to value of phones of p
+                    repeat with ph in phoneList
+                        if ph contains "$PHONE_ESCAPED" then
+                            set phoneMatch to true
+                            exit repeat
+                        end if
+                    end repeat
+                end try
+                if not phoneMatch then set includeContact to false
+            end if
+
+            if includeContact then
+                set end of matchedPeople to p
+            end if
+        end repeat
+    else
+        -- Fast path: only name and/or organization criteria (use 'whose')
+        if "$NAME_ESCAPED" is not "" and "$ORG_ESCAPED" is not "" then
+            set matchedPeople to (every person whose name contains "$NAME_ESCAPED" and organization contains "$ORG_ESCAPED")
+        else if "$NAME_ESCAPED" is not "" then
+            set matchedPeople to (every person whose name contains "$NAME_ESCAPED")
+        else if "$ORG_ESCAPED" is not "" then
+            set matchedPeople to (every person whose organization contains "$ORG_ESCAPED")
+        end if
+    end if
+
+    set totalFound to count of matchedPeople
+    if totalFound is 0 then
+        return "No contacts found matching criteria."
+    end if
+
+    -- Cap at limit
+    if totalFound > $LIMIT then
+        set displayCount to $LIMIT
+    else
+        set displayCount to totalFound
+    end if
+
+    set output to "=== FOUND " & totalFound & " CONTACT(S) ===" & return & return
+
+    repeat with i from 1 to displayCount
+        set p to item i of matchedPeople
+
+        set output to output & "Name: " & name of p & return
+
+        -- Emails
+        try
+            set emailList to emails of p
+            if (count of emailList) > 0 then
+                repeat with e in emailList
+                    set output to output & "Email: " & value of e & return
+                end repeat
+            end if
+        end try
+
+        -- Phones
+        try
+            set phoneList to phones of p
+            if (count of phoneList) > 0 then
+                repeat with ph in phoneList
+                    set output to output & "Phone: " & value of ph & return
+                end repeat
+            end if
+        end try
+
+        -- Organization
+        try
+            set org to organization of p
+            if org is not missing value and org is not "" then
+                set output to output & "Organization: " & org & return
+            end if
+        end try
+
+        set output to output & "---" & return
+    end repeat
+
+    if totalFound > $LIMIT then
+        set output to output & return & "Showing " & displayCount & " of " & totalFound & " results (limit: $LIMIT)"
+    end if
+
+    return output
+end tell
+EOF

--- a/macos-automation/messages/list-chats.sh
+++ b/macos-automation/messages/list-chats.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# ==============================================================================
+# list-chats.sh - List recent iMessage/SMS chats from Messages.app
+# ==============================================================================
+# Description:
+#   Lists recent chats by querying the Messages database (chat.db) using
+#   read-only SQLite access. Shows chat display name or identifier, last
+#   message date, message preview, and message count per chat.
+#   Requires Full Disk Access for the calling process.
+#
+# Usage:
+#   ./list-chats.sh
+#   ./list-chats.sh --limit 10
+#   ./list-chats.sh --days 30
+#
+# Options:
+#   --limit <n>    Maximum number of chats to return (default: 20)
+#   --days <n>     Only show chats with messages in the last n days (default: 7)
+#
+# Example:
+#   ./list-chats.sh --limit 10 --days 14
+#   ./list-chats.sh --days 30
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+LIMIT=20
+DAYS=7
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --limit)
+            LIMIT="$2"
+            shift 2
+            ;;
+        --days)
+            DAYS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            head -23 "$0" | tail -18
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Check if chat.db exists and is readable
+CHAT_DB="$HOME/Library/Messages/chat.db"
+if [[ ! -f "$CHAT_DB" ]]; then
+    error_exit "Messages database not found at $CHAT_DB"
+fi
+
+if [[ ! -r "$CHAT_DB" ]]; then
+    error_exit "Full Disk Access required. Grant in System Settings > Privacy & Security > Full Disk Access"
+fi
+
+# Query the Messages database (read-only mode)
+# Apple epoch: nanoseconds since 2001-01-01 → date/1000000000 + 978307200 = Unix timestamp
+RESULT=$(sqlite3 "file:${CHAT_DB}?mode=ro" <<SQL 2>&1
+.headers off
+.mode list
+.separator "|"
+SELECT
+    c.chat_identifier,
+    COALESCE(NULLIF(c.display_name, ''), c.chat_identifier) AS display,
+    datetime(m.date/1000000000 + 978307200, 'unixepoch', 'localtime') AS last_msg_date,
+    REPLACE(SUBSTR(COALESCE(m.text, ''), 1, 100), CHAR(10), ' ') AS preview,
+    COUNT(cmj.message_id) AS msg_count
+FROM chat c
+JOIN chat_message_join cmj ON c.ROWID = cmj.chat_id
+JOIN message m ON cmj.message_id = m.ROWID
+WHERE m.date/1000000000 + 978307200 > CAST(strftime('%s', 'now', '-${DAYS} days') AS INTEGER)
+GROUP BY c.ROWID
+HAVING m.date = MAX(m.date)
+ORDER BY m.date DESC
+LIMIT ${LIMIT};
+SQL
+)
+
+# Check for errors (e.g., Full Disk Access denied)
+if [[ $? -ne 0 ]]; then
+    if echo "$RESULT" | grep -qi "authorization denied\|unable to open\|not authorized"; then
+        error_exit "Full Disk Access required. Grant in System Settings > Privacy & Security > Full Disk Access"
+    else
+        error_exit "Failed to query Messages database: $RESULT"
+    fi
+fi
+
+if [[ -z "$RESULT" ]]; then
+    echo "No chats found in the last $DAYS day(s)."
+    exit 0
+fi
+
+# Format and display results
+CHAT_COUNT=0
+echo "=== RECENT CHATS (last $DAYS days) ==="
+echo ""
+
+while IFS='|' read -r identifier display last_date preview msg_count; do
+    CHAT_COUNT=$((CHAT_COUNT + 1))
+    echo "Chat: $display"
+    echo "  Identifier: $identifier"
+    echo "  Last message: $last_date"
+    echo "  Messages: $msg_count"
+    if [[ -n "$preview" ]]; then
+        echo "  Preview: $preview"
+    fi
+    echo "---"
+done <<< "$RESULT"
+
+echo ""
+echo "Showing $CHAT_COUNT chat(s)"

--- a/macos-automation/messages/search-messages.sh
+++ b/macos-automation/messages/search-messages.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# ==============================================================================
+# search-messages.sh - Search iMessage/SMS history in Messages.app
+# ==============================================================================
+# Description:
+#   Searches the Messages database (chat.db) for messages matching text content
+#   and/or sender handle. Uses read-only SQLite access. Requires Full Disk
+#   Access for the calling process.
+#
+# Usage:
+#   ./search-messages.sh --query <text>
+#   ./search-messages.sh --from <handle>
+#   ./search-messages.sh --query <text> --from <handle> --days 30
+#
+# Options:
+#   --query <text>     Search for messages containing text
+#   --from <handle>    Filter by sender phone number or email
+#   --days <n>         Only search messages from last n days (default: 7)
+#   --limit <n>        Maximum number of results (default: 20)
+#
+# Example:
+#   ./search-messages.sh --query "dinner" --days 14
+#   ./search-messages.sh --from "+15551234567" --limit 10
+#   ./search-messages.sh --query "meeting" --from "john@example.com" --days 30
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+QUERY=""
+FROM=""
+DAYS=7
+LIMIT=20
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --query)
+            QUERY="$2"
+            shift 2
+            ;;
+        --from)
+            FROM="$2"
+            shift 2
+            ;;
+        --days)
+            DAYS="$2"
+            shift 2
+            ;;
+        --limit)
+            LIMIT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            head -25 "$0" | tail -20
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Validate: at least --query or --from required
+if [[ -z "$QUERY" && -z "$FROM" ]]; then
+    error_exit "At least --query or --from is required"
+fi
+
+# Check if chat.db exists and is readable
+CHAT_DB="$HOME/Library/Messages/chat.db"
+if [[ ! -f "$CHAT_DB" ]]; then
+    error_exit "Messages database not found at $CHAT_DB"
+fi
+
+if [[ ! -r "$CHAT_DB" ]]; then
+    error_exit "Full Disk Access required. Grant in System Settings > Privacy & Security > Full Disk Access"
+fi
+
+# Build WHERE clauses
+WHERE_CLAUSES="m.date/1000000000 + 978307200 > CAST(strftime('%s', 'now', '-${DAYS} days') AS INTEGER)"
+
+if [[ -n "$QUERY" ]]; then
+    # Escape single quotes for SQL
+    QUERY_SQL="${QUERY//\'/\'\'}"
+    WHERE_CLAUSES="$WHERE_CLAUSES AND m.text LIKE '%${QUERY_SQL}%'"
+fi
+
+if [[ -n "$FROM" ]]; then
+    FROM_SQL="${FROM//\'/\'\'}"
+    WHERE_CLAUSES="$WHERE_CLAUSES AND h.id LIKE '%${FROM_SQL}%'"
+fi
+
+# Query the Messages database (read-only mode)
+RESULT=$(sqlite3 "file:${CHAT_DB}?mode=ro" <<SQL 2>&1
+.headers off
+.mode list
+.separator "|"
+SELECT
+    datetime(m.date/1000000000 + 978307200, 'unixepoch', 'localtime') AS msg_date,
+    COALESCE(h.id, 'me') AS sender,
+    COALESCE(c.chat_identifier, '') AS chat,
+    REPLACE(SUBSTR(COALESCE(m.text, ''), 1, 200), CHAR(10), ' ') AS text
+FROM message m
+LEFT JOIN handle h ON m.handle_id = h.ROWID
+LEFT JOIN chat_message_join cmj ON m.ROWID = cmj.message_id
+LEFT JOIN chat c ON cmj.chat_id = c.ROWID
+WHERE $WHERE_CLAUSES
+  AND m.text IS NOT NULL
+  AND m.text != ''
+ORDER BY m.date DESC
+LIMIT ${LIMIT};
+SQL
+)
+
+# Check for errors
+if [[ $? -ne 0 ]]; then
+    if echo "$RESULT" | grep -qi "authorization denied\|unable to open\|not authorized"; then
+        error_exit "Full Disk Access required. Grant in System Settings > Privacy & Security > Full Disk Access"
+    else
+        error_exit "Failed to query Messages database: $RESULT"
+    fi
+fi
+
+if [[ -z "$RESULT" ]]; then
+    echo "No messages found matching criteria in the last $DAYS day(s)."
+    exit 0
+fi
+
+# Format and display results
+MSG_COUNT=0
+SEARCH_DESC=""
+if [[ -n "$QUERY" ]]; then
+    SEARCH_DESC="query=\"$QUERY\""
+fi
+if [[ -n "$FROM" ]]; then
+    [[ -n "$SEARCH_DESC" ]] && SEARCH_DESC="$SEARCH_DESC, "
+    SEARCH_DESC="${SEARCH_DESC}from=\"$FROM\""
+fi
+
+echo "=== MESSAGE SEARCH ($SEARCH_DESC, last $DAYS days) ==="
+echo ""
+
+while IFS='|' read -r msg_date sender chat text; do
+    MSG_COUNT=$((MSG_COUNT + 1))
+    echo "Date: $msg_date"
+    echo "From: $sender"
+    if [[ -n "$chat" ]]; then
+        echo "Chat: $chat"
+    fi
+    echo "Text: $text"
+    echo "---"
+done <<< "$RESULT"
+
+echo ""
+echo "Found $MSG_COUNT message(s)"

--- a/macos-automation/messages/send-message.sh
+++ b/macos-automation/messages/send-message.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# ==============================================================================
+# send-message.sh - Send an iMessage or SMS via Messages.app
+# ==============================================================================
+# Description:
+#   Sends a message to a recipient using Apple Messages. Attempts to send via
+#   iMessage first, and falls back to SMS if iMessage service is unavailable.
+#
+# Usage:
+#   ./send-message.sh --to <phone_or_email> --body <text>
+#
+# Options:
+#   --to <address>     Recipient phone number or email (required)
+#   --body <text>      Message body text (required)
+#
+# Example:
+#   ./send-message.sh --to "+15551234567" --body "Hey, are you free tonight?"
+#   ./send-message.sh --to "john@example.com" --body "Check your email"
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+TO=""
+BODY=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --to)
+            TO="$2"
+            shift 2
+            ;;
+        --body)
+            BODY="$2"
+            shift 2
+            ;;
+        -h|--help)
+            head -20 "$0" | tail -15
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Validate required fields
+[[ -z "$TO" ]] && error_exit "--to is required"
+[[ -z "$BODY" ]] && error_exit "--body is required"
+
+# Escape special characters for AppleScript
+TO_ESCAPED=$(escape_for_applescript "$TO")
+BODY_ESCAPED=$(escape_for_applescript "$BODY")
+
+osascript <<EOF
+tell application "Messages"
+    set recipientAddr to "$TO_ESCAPED"
+    set bodyText to "$BODY_ESCAPED"
+
+    -- Try iMessage first
+    set targetService to missing value
+    try
+        set targetService to 1st service whose service type = iMessage
+    end try
+
+    if targetService is not missing value then
+        try
+            set targetBuddy to a buddy targetService whose handle is recipientAddr
+            send bodyText to targetBuddy
+            return "Message sent to " & recipientAddr & " (iMessage)"
+        on error iMsgErr
+            -- iMessage buddy not found, try SMS
+            set targetService to missing value
+        end try
+    end if
+
+    -- Fall back to SMS
+    if targetService is missing value then
+        try
+            set targetService to 1st service whose service type = SMS
+        on error
+            return "Error: No iMessage or SMS service available"
+        end try
+
+        try
+            set targetBuddy to a buddy targetService whose handle is recipientAddr
+            send bodyText to targetBuddy
+            return "Message sent to " & recipientAddr & " (SMS)"
+        on error smsErr
+            return "Error: Could not send message to " & recipientAddr & ". " & smsErr
+        end try
+    end if
+end tell
+EOF

--- a/macos-automation/system/get-system-status.sh
+++ b/macos-automation/system/get-system-status.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# ==============================================================================
+# get-system-status.sh - Report current macOS system status
+# ==============================================================================
+# Description:
+#   Reports the current state of key system settings including WiFi, Bluetooth,
+#   volume, dark mode, and Do Not Disturb.
+#
+# Usage:
+#   ./get-system-status.sh
+#
+# Options:
+#   -h, --help    Show this help message
+#
+# Example:
+#   ./get-system-status.sh
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            head -18 "$0" | tail -13
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# --- WiFi ---
+WIFI_DEVICE=$(networksetup -listallhardwareports | awk '/Wi-Fi/{getline; print $2}')
+if [[ -n "$WIFI_DEVICE" ]]; then
+    WIFI_POWER=$(networksetup -getairportpower "$WIFI_DEVICE" 2>/dev/null | awk '{print $NF}')
+    if [[ "$WIFI_POWER" == "On" ]]; then
+        WIFI_NETWORK=$(networksetup -getairportnetwork "$WIFI_DEVICE" 2>/dev/null | sed 's/^Current Wi-Fi Network: //')
+        if [[ "$WIFI_NETWORK" == "You are not associated with an AirPort network." ]]; then
+            WIFI_STATUS="On (not connected)"
+        else
+            WIFI_STATUS="On ($WIFI_NETWORK)"
+        fi
+    else
+        WIFI_STATUS="Off"
+    fi
+else
+    WIFI_STATUS="No WiFi device found"
+fi
+
+# --- Bluetooth ---
+BT_STATE=$(osascript -l JavaScript -e '
+ObjC.import("IOBluetooth");
+var state = $.IOBluetoothPreferenceGetControllerPowerState();
+state == 1 ? "On" : "Off";
+' 2>/dev/null)
+if [[ -z "$BT_STATE" ]]; then
+    BT_STATE="Unknown"
+fi
+
+# --- Volume ---
+VOLUME_LEVEL=$(osascript -e 'output volume of (get volume settings)' 2>/dev/null)
+VOLUME_MUTED=$(osascript -e 'output muted of (get volume settings)' 2>/dev/null)
+if [[ "$VOLUME_MUTED" == "true" ]]; then
+    VOLUME_STATUS="$VOLUME_LEVEL% (muted)"
+else
+    VOLUME_STATUS="$VOLUME_LEVEL%"
+fi
+
+# --- Dark Mode ---
+DARK_MODE=$(osascript -e 'tell application "System Events" to tell appearance preferences to get dark mode' 2>/dev/null)
+if [[ "$DARK_MODE" == "true" ]]; then
+    DARK_MODE_STATUS="On"
+else
+    DARK_MODE_STATUS="Off"
+fi
+
+# --- Do Not Disturb ---
+# DND is hard to detect reliably; best-effort check
+DND_STATUS="Unknown"
+DND_VALUE=$(defaults read com.apple.controlcenter "NSStatusItem Visible FocusModes" 2>/dev/null)
+if [[ "$DND_VALUE" == "1" ]]; then
+    DND_STATUS="Focus active (best effort)"
+elif [[ "$DND_VALUE" == "0" ]]; then
+    DND_STATUS="Off (best effort)"
+fi
+
+# --- Output ---
+echo "=== SYSTEM STATUS ==="
+echo ""
+echo "WiFi: $WIFI_STATUS"
+echo "Bluetooth: $BT_STATE"
+echo "Volume: $VOLUME_STATUS"
+echo "Dark Mode: $DARK_MODE_STATUS"
+echo "Do Not Disturb: $DND_STATUS"

--- a/macos-automation/system/list-bluetooth-devices.sh
+++ b/macos-automation/system/list-bluetooth-devices.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# ==============================================================================
+# list-bluetooth-devices.sh - List paired Bluetooth devices
+# ==============================================================================
+# Description:
+#   Lists paired Bluetooth devices showing name, connection status, and address.
+#   Can filter to show only connected devices.
+#
+# Usage:
+#   ./list-bluetooth-devices.sh
+#   ./list-bluetooth-devices.sh --connected-only
+#   ./list-bluetooth-devices.sh --limit 10
+#
+# Options:
+#   --connected-only  Only show currently connected devices
+#   --limit <n>       Maximum number of devices to show (default: 20)
+#   -h, --help        Show this help message
+#
+# Example:
+#   ./list-bluetooth-devices.sh
+#   ./list-bluetooth-devices.sh --connected-only
+#   ./list-bluetooth-devices.sh --limit 5
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+CONNECTED_ONLY=false
+LIMIT=20
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --connected-only)
+            CONNECTED_ONLY=true
+            shift
+            ;;
+        --limit)
+            LIMIT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            head -25 "$0" | tail -20
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+osascript -l JavaScript -e "
+ObjC.import('IOBluetooth');
+
+var devices = $.IOBluetoothDevice.pairedDevices();
+var count = devices.count;
+var connectedOnly = $CONNECTED_ONLY;
+var limit = $LIMIT;
+var results = [];
+
+for (var i = 0; i < count; i++) {
+    var device = devices.objectAtIndex(i);
+    var name = '';
+    try { name = ObjC.unwrap(device.name); } catch(e) { name = '(unknown)'; }
+    var address = '';
+    try { address = ObjC.unwrap(device.addressString); } catch(e) { address = ''; }
+    var connected = device.isConnected();
+
+    if (connectedOnly && !connected) continue;
+
+    results.push({
+        name: name || '(unknown)',
+        address: address || '(unknown)',
+        connected: connected ? 'Yes' : 'No'
+    });
+
+    if (results.length >= limit) break;
+}
+
+if (results.length === 0) {
+    if (connectedOnly) {
+        'No connected Bluetooth devices found.';
+    } else {
+        'No paired Bluetooth devices found.';
+    }
+} else {
+    var output = '=== BLUETOOTH DEVICES ===\n\n';
+    for (var j = 0; j < results.length; j++) {
+        var d = results[j];
+        output += 'Name: ' + d.name + '\n';
+        output += 'Address: ' + d.address + '\n';
+        output += 'Connected: ' + d.connected + '\n';
+        output += '---\n';
+    }
+    output += '\nTotal: ' + results.length + ' device(s)';
+    output;
+}
+" 2>/dev/null
+
+if [[ $? -ne 0 ]]; then
+    error_exit "Failed to list Bluetooth devices. IOBluetooth framework may not be available."
+fi

--- a/macos-automation/system/set-volume.sh
+++ b/macos-automation/system/set-volume.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# ==============================================================================
+# set-volume.sh - Set system volume level and mute state
+# ==============================================================================
+# Description:
+#   Sets the system output volume level (0-100) and/or mute/unmute state.
+#   Can combine level and mute options in a single call. Reports the
+#   resulting state after changes are applied.
+#
+# Usage:
+#   ./set-volume.sh --level 50
+#   ./set-volume.sh --mute
+#   ./set-volume.sh --unmute
+#   ./set-volume.sh --level 75 --unmute
+#
+# Options:
+#   --level <0-100>   Set volume level (0 to 100)
+#   --mute            Mute audio output
+#   --unmute          Unmute audio output
+#   -h, --help        Show this help message
+#
+# Example:
+#   ./set-volume.sh --level 50
+#   ./set-volume.sh --mute
+#   ./set-volume.sh --level 30 --unmute
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+LEVEL=""
+MUTE_ACTION=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --level)
+            LEVEL="$2"
+            shift 2
+            ;;
+        --mute)
+            MUTE_ACTION="mute"
+            shift
+            ;;
+        --unmute)
+            MUTE_ACTION="unmute"
+            shift
+            ;;
+        -h|--help)
+            head -26 "$0" | tail -21
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Validate at least one argument
+[[ -z "$LEVEL" && -z "$MUTE_ACTION" ]] && error_exit "Please specify --level, --mute, or --unmute"
+
+# Validate level range
+if [[ -n "$LEVEL" ]]; then
+    if ! [[ "$LEVEL" =~ ^[0-9]+$ ]] || [[ "$LEVEL" -lt 0 ]] || [[ "$LEVEL" -gt 100 ]]; then
+        error_exit "Volume level must be a number between 0 and 100"
+    fi
+fi
+
+# Apply volume level
+if [[ -n "$LEVEL" ]]; then
+    osascript -e "set volume output volume $LEVEL" 2>/dev/null
+fi
+
+# Apply mute/unmute
+if [[ "$MUTE_ACTION" == "mute" ]]; then
+    osascript -e 'set volume output muted true' 2>/dev/null
+elif [[ "$MUTE_ACTION" == "unmute" ]]; then
+    osascript -e 'set volume output muted false' 2>/dev/null
+fi
+
+# Report current state
+CURRENT_LEVEL=$(osascript -e 'output volume of (get volume settings)' 2>/dev/null)
+CURRENT_MUTED=$(osascript -e 'output muted of (get volume settings)' 2>/dev/null)
+
+if [[ "$CURRENT_MUTED" == "true" ]]; then
+    echo "Volume: ${CURRENT_LEVEL}% (muted)"
+else
+    echo "Volume: ${CURRENT_LEVEL}%"
+fi

--- a/macos-automation/system/toggle-bluetooth.sh
+++ b/macos-automation/system/toggle-bluetooth.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# ==============================================================================
+# toggle-bluetooth.sh - Toggle Bluetooth on or off
+# ==============================================================================
+# Description:
+#   Turns Bluetooth on, off, or toggles the current state. Uses JXA with
+#   IOBluetooth framework. Falls back to blueutil if available.
+#   Idempotent: reports if already in the desired state.
+#
+# Usage:
+#   ./toggle-bluetooth.sh
+#   ./toggle-bluetooth.sh --on
+#   ./toggle-bluetooth.sh --off
+#
+# Options:
+#   --on          Turn Bluetooth on
+#   --off         Turn Bluetooth off
+#   (no args)     Toggle current state
+#   -h, --help    Show this help message
+#
+# Example:
+#   ./toggle-bluetooth.sh --on
+#   ./toggle-bluetooth.sh --off
+#   ./toggle-bluetooth.sh
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+ACTION=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --on)
+            ACTION="on"
+            shift
+            ;;
+        --off)
+            ACTION="off"
+            shift
+            ;;
+        -h|--help)
+            head -26 "$0" | tail -21
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Get current Bluetooth state
+get_bt_state() {
+    if command -v blueutil &>/dev/null; then
+        local power
+        power=$(blueutil -p 2>/dev/null)
+        if [[ "$power" == "1" ]]; then
+            echo "on"
+        else
+            echo "off"
+        fi
+    else
+        local state
+        state=$(osascript -l JavaScript -e '
+ObjC.import("IOBluetooth");
+$.IOBluetoothPreferenceGetControllerPowerState();
+' 2>/dev/null)
+        if [[ "$state" == "1" ]]; then
+            echo "on"
+        else
+            echo "off"
+        fi
+    fi
+}
+
+# Set Bluetooth state (1 for on, 0 for off)
+set_bt_state() {
+    local desired="$1"
+    if command -v blueutil &>/dev/null; then
+        blueutil -p "$desired" 2>/dev/null
+    else
+        osascript -l JavaScript -e "
+ObjC.import('IOBluetooth');
+$.IOBluetoothPreferenceSetControllerPowerState($desired);
+" 2>/dev/null
+    fi
+}
+
+# Get current state
+CURRENT_STATE=$(get_bt_state)
+
+# Determine desired state
+if [[ -z "$ACTION" ]]; then
+    # Toggle
+    if [[ "$CURRENT_STATE" == "on" ]]; then
+        ACTION="off"
+    else
+        ACTION="on"
+    fi
+fi
+
+# Apply
+if [[ "$ACTION" == "on" ]]; then
+    if [[ "$CURRENT_STATE" == "on" ]]; then
+        echo "Bluetooth already on"
+    else
+        set_bt_state 1
+        echo "Bluetooth turned on"
+    fi
+elif [[ "$ACTION" == "off" ]]; then
+    if [[ "$CURRENT_STATE" == "off" ]]; then
+        echo "Bluetooth already off"
+    else
+        set_bt_state 0
+        echo "Bluetooth turned off"
+    fi
+fi

--- a/macos-automation/system/toggle-dark-mode.sh
+++ b/macos-automation/system/toggle-dark-mode.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# ==============================================================================
+# toggle-dark-mode.sh - Toggle macOS dark mode on or off
+# ==============================================================================
+# Description:
+#   Enables, disables, or toggles macOS dark mode. Checks the current state
+#   first for idempotent behavior.
+#
+# Usage:
+#   ./toggle-dark-mode.sh
+#   ./toggle-dark-mode.sh --on
+#   ./toggle-dark-mode.sh --off
+#
+# Options:
+#   --on          Enable dark mode
+#   --off         Disable dark mode
+#   (no args)     Toggle current state
+#   -h, --help    Show this help message
+#
+# Example:
+#   ./toggle-dark-mode.sh --on
+#   ./toggle-dark-mode.sh --off
+#   ./toggle-dark-mode.sh
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+ACTION=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --on)
+            ACTION="on"
+            shift
+            ;;
+        --off)
+            ACTION="off"
+            shift
+            ;;
+        -h|--help)
+            head -25 "$0" | tail -20
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Get current state
+CURRENT_STATE=$(osascript -e 'tell application "System Events" to tell appearance preferences to get dark mode' 2>/dev/null)
+
+# Determine desired state
+if [[ -z "$ACTION" ]]; then
+    # Toggle
+    if [[ "$CURRENT_STATE" == "true" ]]; then
+        ACTION="off"
+    else
+        ACTION="on"
+    fi
+fi
+
+# Apply
+if [[ "$ACTION" == "on" ]]; then
+    if [[ "$CURRENT_STATE" == "true" ]]; then
+        echo "Dark mode already enabled"
+    else
+        osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to true' 2>/dev/null
+        echo "Dark mode enabled"
+    fi
+elif [[ "$ACTION" == "off" ]]; then
+    if [[ "$CURRENT_STATE" == "false" ]]; then
+        echo "Dark mode already disabled"
+    else
+        osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to false' 2>/dev/null
+        echo "Dark mode disabled"
+    fi
+fi

--- a/macos-automation/system/toggle-dnd.sh
+++ b/macos-automation/system/toggle-dnd.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# ==============================================================================
+# toggle-dnd.sh - Toggle Do Not Disturb via Shortcuts
+# ==============================================================================
+# Description:
+#   Toggles Do Not Disturb (Focus mode) using a macOS Shortcut. Requires a
+#   shortcut named "Toggle Do Not Disturb" to be set up in Shortcuts.app.
+#   Provides setup instructions if the shortcut is not found.
+#
+# Usage:
+#   ./toggle-dnd.sh
+#   ./toggle-dnd.sh --on
+#   ./toggle-dnd.sh --off
+#
+# Options:
+#   --on          Turn Do Not Disturb on
+#   --off         Turn Do Not Disturb off
+#   (no args)     Toggle current state
+#   -h, --help    Show this help message
+#
+# Example:
+#   ./toggle-dnd.sh
+#   ./toggle-dnd.sh --on
+#   ./toggle-dnd.sh --off
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+ACTION=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --on)
+            ACTION="on"
+            shift
+            ;;
+        --off)
+            ACTION="off"
+            shift
+            ;;
+        -h|--help)
+            head -25 "$0" | tail -20
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Check if shortcuts CLI exists
+if ! command -v shortcuts &>/dev/null; then
+    error_exit "shortcuts command not found. Requires macOS 12 (Monterey) or later."
+fi
+
+# Determine which shortcut to run based on action
+if [[ "$ACTION" == "on" ]]; then
+    SHORTCUT_NAME="Turn On Do Not Disturb"
+elif [[ "$ACTION" == "off" ]]; then
+    SHORTCUT_NAME="Turn Off Do Not Disturb"
+else
+    SHORTCUT_NAME="Toggle Do Not Disturb"
+fi
+
+# Check if the shortcut exists
+if ! shortcuts list 2>/dev/null | grep -q "^${SHORTCUT_NAME}$"; then
+    # Fall back to the toggle shortcut for on/off if specific ones don't exist
+    if [[ -n "$ACTION" ]]; then
+        SHORTCUT_NAME="Toggle Do Not Disturb"
+        if ! shortcuts list 2>/dev/null | grep -q "^${SHORTCUT_NAME}$"; then
+            echo "Shortcut 'Toggle Do Not Disturb' not found. To set up:"
+            echo "  1. Open Shortcuts.app"
+            echo "  2. Create a new shortcut named 'Toggle Do Not Disturb'"
+            echo "  3. Add action: 'Set Focus' -> 'Do Not Disturb' -> Toggle"
+            echo "  4. Save and try again"
+            exit 1
+        fi
+    else
+        echo "Shortcut 'Toggle Do Not Disturb' not found. To set up:"
+        echo "  1. Open Shortcuts.app"
+        echo "  2. Create a new shortcut named 'Toggle Do Not Disturb'"
+        echo "  3. Add action: 'Set Focus' -> 'Do Not Disturb' -> Toggle"
+        echo "  4. Save and try again"
+        exit 1
+    fi
+fi
+
+# Run the shortcut
+if shortcuts run "$SHORTCUT_NAME" 2>/dev/null; then
+    echo "Do Not Disturb toggled"
+else
+    error_exit "Failed to run shortcut '$SHORTCUT_NAME'"
+fi

--- a/macos-automation/system/toggle-wifi.sh
+++ b/macos-automation/system/toggle-wifi.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# ==============================================================================
+# toggle-wifi.sh - Toggle WiFi on or off
+# ==============================================================================
+# Description:
+#   Turns WiFi on, off, or toggles the current state. Auto-detects the WiFi
+#   hardware device. Idempotent: reports if already in the desired state.
+#
+# Usage:
+#   ./toggle-wifi.sh
+#   ./toggle-wifi.sh --on
+#   ./toggle-wifi.sh --off
+#
+# Options:
+#   --on          Turn WiFi on
+#   --off         Turn WiFi off
+#   (no args)     Toggle current state
+#   -h, --help    Show this help message
+#
+# Example:
+#   ./toggle-wifi.sh --on
+#   ./toggle-wifi.sh --off
+#   ./toggle-wifi.sh
+# ==============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Default values
+ACTION=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --on)
+            ACTION="on"
+            shift
+            ;;
+        --off)
+            ACTION="off"
+            shift
+            ;;
+        -h|--help)
+            head -25 "$0" | tail -20
+            exit 0
+            ;;
+        *)
+            error_exit "Unknown option: $1"
+            ;;
+    esac
+done
+
+# Auto-detect WiFi device
+WIFI_DEVICE=$(networksetup -listallhardwareports | awk '/Wi-Fi/{getline; print $2}')
+[[ -z "$WIFI_DEVICE" ]] && error_exit "No WiFi device found"
+
+# Get current state
+CURRENT_POWER=$(networksetup -getairportpower "$WIFI_DEVICE" 2>/dev/null | awk '{print $NF}')
+
+# Determine desired state
+if [[ -z "$ACTION" ]]; then
+    # Toggle
+    if [[ "$CURRENT_POWER" == "On" ]]; then
+        ACTION="off"
+    else
+        ACTION="on"
+    fi
+fi
+
+# Apply
+if [[ "$ACTION" == "on" ]]; then
+    if [[ "$CURRENT_POWER" == "On" ]]; then
+        echo "WiFi already on"
+    else
+        networksetup -setairportpower "$WIFI_DEVICE" on
+        echo "WiFi turned on"
+    fi
+elif [[ "$ACTION" == "off" ]]; then
+    if [[ "$CURRENT_POWER" == "Off" ]]; then
+        echo "WiFi already off"
+    else
+        networksetup -setairportpower "$WIFI_DEVICE" off
+        echo "WiFi turned off"
+    fi
+fi

--- a/skills/contacts_assistant/SKILL.md
+++ b/skills/contacts_assistant/SKILL.md
@@ -1,0 +1,51 @@
+---
+id: contacts_assistant
+name: Contacts Assistant
+description: Look up, search, and create contacts in Contacts.app.
+apps:
+  - Contacts
+tasks:
+  - search_contacts
+  - get_contact
+  - create_contact
+  - list_contact_groups
+examples:
+  - "What's Joe's phone number?"
+  - "Find contacts at Acme Corp"
+  - "Look up Sarah's email address"
+  - "Add a new contact for John Smith"
+  - "Show me all contact groups"
+safe_defaults:
+  limit: 20
+confirm_before_write:
+  - create contact
+requires_permissions:
+  - Automation:Contacts
+---
+
+## Behavior Notes
+
+### Search Strategy
+- **Search by name first** — it uses a `whose` clause and is near-instant.
+- Fall back to email or phone search only when name search returns nothing or user explicitly provides an email/phone.
+- Organization search also uses `whose` (fast).
+
+### Getting Full Contact Details
+- Use `search_contacts` to find the person first (returns summary: name, primary email/phone).
+- Then use `get_contact` with the exact name to fetch the full card (all emails, phones, addresses, notes, birthday, groups).
+
+### Creating Contacts
+- Always confirm the details before creating a new contact.
+- `first_name` is required; all other fields are optional.
+- Multiple emails and phones can be provided.
+- If a group is specified, it must already exist in Contacts.app.
+
+### Groups
+- Use `list_contact_groups` to see available groups before assigning contacts.
+- Groups cannot be created via automation — they must be created manually in Contacts.app.
+
+### Common Request Patterns
+- **"What's X's number?"** → `search_contacts(name="X")` → `get_contact(name="X")`
+- **"Find contacts at Acme"** → `search_contacts(organization="Acme")`
+- **"Add John Smith"** → confirm details → `create_contact(first_name="John", last_name="Smith", ...)`
+- **"Show my groups"** → `list_contact_groups()`

--- a/skills/messages_assistant/SKILL.md
+++ b/skills/messages_assistant/SKILL.md
@@ -1,0 +1,58 @@
+---
+id: messages_assistant
+name: Messages Assistant
+description: Send iMessages and search message history via Messages.app and chat.db.
+apps:
+  - Messages
+tasks:
+  - send_imessage
+  - list_imessage_chats
+  - search_imessages
+examples:
+  - "Send a message to +15551234567 saying hello"
+  - "Show my recent chats"
+  - "Search messages from Mom in the last week"
+  - "What did John say about dinner?"
+safe_defaults:
+  limit: 20
+  days: 7
+confirm_before_write:
+  - send message
+requires_permissions:
+  - Automation:Messages
+  - Full Disk Access
+---
+
+## Behavior Notes
+
+### Sending Messages
+- **Always confirm message content and recipient before sending.** Show the user exactly what will be sent.
+- The `--to` parameter accepts phone numbers (with country code, e.g., +15551234567) or Apple ID emails.
+- Messages are sent via iMessage by default. If the recipient is not on iMessage, delivery may fail silently.
+
+### Reading Message History
+- `list_imessage_chats` and `search_imessages` read directly from `~/Library/Messages/chat.db`.
+- **chat.db is READ-ONLY** — never attempt to modify it. Modifying breaks iCloud sync.
+- **Full Disk Access is required** to read chat.db. If access is denied, guide the user:
+  "Grant Full Disk Access in System Settings > Privacy & Security > Full Disk Access for your terminal app."
+
+### Search Strategy
+- Use `search_imessages` with `--query` for text search and `--from` for sender filter.
+- Narrow by `--days` (default 7) to keep queries fast.
+- Combine `--query` and `--from` for precise results.
+
+### Date Handling
+- Messages uses Apple's CoreData epoch: nanoseconds since 2001-01-01.
+- The scripts handle conversion automatically — dates are shown in local time.
+
+### Common Request Patterns
+- **"Send X a message"** → confirm content → `send_imessage(to="...", body="...")`
+- **"Show recent chats"** → `list_imessage_chats(days=7)`
+- **"What did X say about Y?"** → `search_imessages(query="Y", from="X")`
+- **"Messages from last month"** → `search_imessages(days=30)`
+
+### Limitations
+- Cannot send MMS/SMS directly (iMessage only via AppleScript).
+- Cannot read or send attachments via automation.
+- Cannot delete or modify existing messages.
+- Group chat names may appear as participant lists if no custom name is set.

--- a/skills/system_controls/SKILL.md
+++ b/skills/system_controls/SKILL.md
@@ -1,0 +1,76 @@
+---
+id: system_controls
+name: System Controls
+description: Control WiFi, Bluetooth, volume, dark mode, and Do Not Disturb.
+apps:
+  - System Settings
+tasks:
+  - get_system_status
+  - toggle_wifi
+  - toggle_bluetooth
+  - list_bluetooth_devices
+  - set_volume
+  - toggle_dark_mode
+  - toggle_dnd
+examples:
+  - "Turn off WiFi"
+  - "Set volume to 50%"
+  - "Enable dark mode"
+  - "What's my system status?"
+  - "Turn on Do Not Disturb"
+  - "Show connected Bluetooth devices"
+  - "Mute the volume"
+safe_defaults: {}
+confirm_before_write:
+  - toggle wifi off
+  - toggle bluetooth off
+requires_permissions:
+  - Automation:System Events
+---
+
+## Behavior Notes
+
+### System Status
+- Use `get_system_status` to check current state before making changes.
+- Reports: WiFi (on/off + network name), Bluetooth (on/off), volume (% + muted), dark mode, DND.
+
+### Toggle Pattern
+- All toggle tasks accept `--on`, `--off`, or no args (toggle).
+- **Check current state first** — toggles are idempotent. If WiFi is already on and user says "turn on WiFi", report that it's already on rather than toggling.
+- Confirm before turning **off** WiFi or Bluetooth (may disconnect the user).
+
+### WiFi
+- Auto-detects the WiFi hardware device via `networksetup -listallhardwareports`.
+- Shows current network name when WiFi is on.
+
+### Bluetooth
+- Uses IOBluetooth framework via JavaScript for Automation (no third-party deps).
+- Falls back to `blueutil` if ASObjC approach fails.
+- `list_bluetooth_devices` shows paired devices with connection status.
+- **Cannot programmatically connect/disconnect specific Bluetooth devices** — only toggle the adapter on/off.
+
+### Volume
+- Level range: 0-100.
+- Can set level, mute, or unmute independently or together.
+- "Mute" keeps the volume level but silences output; "unmute" restores it.
+
+### Dark Mode
+- Toggles macOS system-wide dark/light appearance.
+- Requires Automation permission for System Events.
+
+### Do Not Disturb
+- Uses a Shortcuts bridge — requires a shortcut named "Toggle Do Not Disturb".
+- If the shortcut doesn't exist, the script outputs setup instructions.
+- Guide the user to create the shortcut if needed:
+  1. Open Shortcuts.app
+  2. Create a new shortcut named "Toggle Do Not Disturb"
+  3. Add the "Set Focus" action → select "Do Not Disturb" → set to "Toggle"
+  4. Save
+
+### Common Request Patterns
+- **"Turn off WiFi"** → confirm → `toggle_wifi(state="off")`
+- **"Set volume to 50"** → `set_volume(level=50)`
+- **"Mute"** → `set_volume(mute=true)`
+- **"Dark mode on"** → `toggle_dark_mode(state="on")`
+- **"What's connected?"** → `list_bluetooth_devices(connected_only=true)`
+- **"Status check"** → `get_system_status()`

--- a/src/macbot/cli.py
+++ b/src/macbot/cli.py
@@ -1681,6 +1681,18 @@ def cmd_doctor(args: argparse.Namespace) -> None:
     check("Safari.app", ok, msg,
           "Grant access in System Settings > Privacy & Security > Automation" if not ok else None)
 
+    # Test Contacts
+    ok, msg = test_app_access("Contacts", 'tell application "Contacts" to count of people')
+    results["permissions"]["automation"]["Contacts"] = ok
+    check("Contacts.app", ok, msg,
+          "Grant access in System Settings > Privacy & Security > Automation" if not ok else None)
+
+    # Test Messages
+    ok, msg = test_app_access("Messages", 'tell application "Messages" to count of services')
+    results["permissions"]["automation"]["Messages"] = ok
+    check("Messages.app", ok, msg,
+          "Grant access in System Settings > Privacy & Security > Automation" if not ok else None)
+
     # Folder Access
     if not json_mode:
         console.print("\n[bold]Folder Access[/bold]")
@@ -1706,6 +1718,16 @@ def cmd_doctor(args: argparse.Namespace) -> None:
         results["permissions"]["folder_access"][folder_name] = accessible
         check(f"~/{folder_name}", accessible, msg,
               "Grant access in System Settings > Privacy & Security > Files and Folders" if not accessible else None)
+
+    # Test Full Disk Access (needed for Messages chat.db)
+    chat_db = os.path.expanduser("~/Library/Messages/chat.db")
+    if os.path.exists(chat_db) and os.access(chat_db, os.R_OK):
+        results["permissions"]["full_disk_access"] = True
+        check("Full Disk Access", True, "chat.db readable")
+    else:
+        results["permissions"]["full_disk_access"] = False
+        check("Full Disk Access", False, "Cannot read ~/Library/Messages/chat.db",
+              "Grant Full Disk Access in System Settings > Privacy & Security > Full Disk Access")
 
     # Browser Automation Tools
     if not json_mode:


### PR DESCRIPTION
Add three new capability areas following the existing three-layer pattern (shell scripts + Python tasks + skill files):

- Contacts.app: search, get details, create contacts, list groups (4 scripts)
- Messages/iMessage: send messages, list chats, search history via chat.db (3 scripts)
- System Controls: WiFi, Bluetooth, volume, dark mode, DND toggles (7 scripts)

Each area includes a SKILL.md for agent guidance and is registered in register_macos_tasks(). Doctor checks added for Contacts, Messages, and Full Disk Access permissions.