### PR TITLE
Reduce Pico tool count from 88 to 24 via essential_tasks and fix prot…

### DIFF
--- a/skills/browser_automation/SKILL.md
+++ b/skills/browser_automation/SKILL.md
@@ -20,6 +20,7 @@ tasks:
   - browser_press_key
   - browser_visual_snapshot
   - analyze_screenshot
+essential_tasks: []
 examples:
   - "Book a table at Restaurant XYZ for Friday at 7pm"
   - "Make a reservation for 2 people tomorrow night"

--- a/skills/calendar_assistant/SKILL.md
+++ b/skills/calendar_assistant/SKILL.md
@@ -9,6 +9,9 @@ tasks:
   - get_week_events
   - create_calendar_event
   - list_calendars
+essential_tasks:
+  - get_today_events
+  - create_calendar_event
 examples:
   - "What's on my calendar today?"
   - "Show me my schedule for this week"

--- a/skills/clawhub/SKILL.md
+++ b/skills/clawhub/SKILL.md
@@ -5,6 +5,7 @@ description: Search, install, and manage community skills from the ClawHub regis
 tasks:
   - run_shell_command
   - enrich_skill
+essential_tasks: []
 examples:
   - "Search ClawHub for a Slack skill"
   - "Install the weather skill from ClawHub"

--- a/skills/contacts_assistant/SKILL.md
+++ b/skills/contacts_assistant/SKILL.md
@@ -9,6 +9,7 @@ tasks:
   - get_contact
   - create_contact
   - list_contact_groups
+essential_tasks: []
 examples:
   - "What's Joe's phone number?"
   - "Find contacts at Acme Corp"

--- a/skills/core_utilities/SKILL.md
+++ b/skills/core_utilities/SKILL.md
@@ -1,0 +1,23 @@
+---
+id: core_utilities
+name: Core Utilities
+description: File system access, shell commands, and time utilities.
+tasks:
+  - run_shell_command
+  - read_file
+  - write_file
+  - get_current_time
+  - fetch_url
+  - list_directory
+  - get_preferences
+essential_tasks:
+  - run_shell_command
+  - read_file
+  - write_file
+  - get_current_time
+safe_defaults: {}
+confirm_before_write:
+  - delete files
+  - overwrite files
+requires_permissions: []
+---

--- a/skills/data_app_creator/SKILL.md
+++ b/skills/data_app_creator/SKILL.md
@@ -12,6 +12,7 @@ tasks:
   - web_fetch
   - fetch_url
   - web_search
+essential_tasks: []
 examples:
   - "Create a dashboard from my bank statement CSV"
   - "Build an app to explore this spending data"

--- a/skills/downloads_organizer/SKILL.md
+++ b/skills/downloads_organizer/SKILL.md
@@ -8,6 +8,7 @@ tasks:
   - list_directory
   - run_shell_command
   - spotlight_search
+essential_tasks: []
 examples:
   - "Organize my Downloads folder"
   - "Clean up Downloads"

--- a/skills/mail_assistant/SKILL.md
+++ b/skills/mail_assistant/SKILL.md
@@ -11,6 +11,10 @@ tasks:
   - download_attachments
   - get_unread_emails
   - mark_emails_read
+essential_tasks:
+  - search_emails
+  - get_unread_emails
+  - send_email
 examples:
   - "Summarize unread emails from today"
   - "Find emails from UPS and show tracking numbers"

--- a/skills/messages_assistant/SKILL.md
+++ b/skills/messages_assistant/SKILL.md
@@ -8,6 +8,9 @@ tasks:
   - send_imessage
   - list_imessage_chats
   - search_imessages
+essential_tasks:
+  - send_imessage
+  - search_imessages
 examples:
   - "Send a message to +15551234567 saying hello"
   - "Show my recent chats"

--- a/skills/mindwtr/SKILL.md
+++ b/skills/mindwtr/SKILL.md
@@ -22,6 +22,7 @@ tasks:
   - mindwtr_update_checklist
   - mindwtr_list_tags
   - mindwtr_search
+essential_tasks: []
 examples:
   - "Add a task to buy groceries tomorrow"
   - "Show me my next actions"

--- a/skills/notes_assistant/SKILL.md
+++ b/skills/notes_assistant/SKILL.md
@@ -15,6 +15,10 @@ tasks:
   - delete_note
   - rename_note_folder
   - delete_note_folder
+essential_tasks:
+  - search_notes
+  - read_note
+  - create_note
 examples:
   - "Search my notes for the wifi password"
   - "Create a note about today's meeting"

--- a/skills/powerpoint/SKILL.md
+++ b/skills/powerpoint/SKILL.md
@@ -8,6 +8,7 @@ tasks:
   - run_shell_command
   - read_file
   - spotlight_search
+essential_tasks: []
 examples:
   - "Summarize this PowerPoint presentation"
   - "What are the key points in slides.pptx?"

--- a/skills/reminders_assistant/SKILL.md
+++ b/skills/reminders_assistant/SKILL.md
@@ -9,6 +9,9 @@ tasks:
   - list_reminders
   - complete_reminder
   - get_due_today_reminders
+essential_tasks:
+  - create_reminder
+  - list_reminders
 examples:
   - "Remind me to call mom at 5pm"
   - "Add a reminder to buy groceries tomorrow morning"

--- a/skills/safari_assistant/SKILL.md
+++ b/skills/safari_assistant/SKILL.md
@@ -11,6 +11,10 @@ tasks:
   - extract_safari_links
   - web_search
   - web_fetch
+essential_tasks:
+  - open_url_in_safari
+  - web_search
+  - web_fetch
 examples:
   - "Open GitHub in Safari"
   - "Show me my open tabs"

--- a/skills/system_controls/SKILL.md
+++ b/skills/system_controls/SKILL.md
@@ -12,6 +12,8 @@ tasks:
   - set_volume
   - toggle_dark_mode
   - toggle_dnd
+essential_tasks:
+  - get_system_status
 examples:
   - "Turn off WiFi"
   - "Set volume to 50%"

--- a/skills/teams_assistant/SKILL.md
+++ b/skills/teams_assistant/SKILL.md
@@ -15,6 +15,7 @@ tasks:
   - teams_list_chats
   - teams_read_chat_messages
   - teams_send_chat_message
+essential_tasks: []
 examples:
   - "Set up Teams integration"
   - "List my Teams"

--- a/skills/things_assistant/SKILL.md
+++ b/skills/things_assistant/SKILL.md
@@ -16,6 +16,10 @@ tasks:
   - list_things_projects
   - create_things_project
   - list_things_tags
+essential_tasks:
+  - show_things_today
+  - create_things_todo
+  - complete_things_todo
 examples:
   - "Show my Things today list"
   - "What's in my Things inbox?"

--- a/src/macbot/core/agent.py
+++ b/src/macbot/core/agent.py
@@ -367,7 +367,7 @@ On subsequent requests for the same site, **check memory first** (`memory_list`)
             return self.task_registry.get_tool_schemas()
 
         # compact/minimal: use only tools from enabled skills
-        schemas = self.skills_registry.get_all_tool_schemas(self.task_registry)
+        schemas = self.skills_registry.get_all_tool_schemas(self.task_registry, compact=True)
 
         if profile in ("compact", "minimal"):
             # Strip parameter descriptions to save tokens

--- a/src/macbot/providers/litellm_provider.py
+++ b/src/macbot/providers/litellm_provider.py
@@ -174,34 +174,58 @@ class LiteLLMProvider(LLMProvider):
         # Build messages in OpenAI format (LiteLLM uses this internally)
         litellm_messages: list[dict[str, Any]] = []
 
+        # Some local model servers (e.g. Pico) don't support tool_call /
+        # tool roles in their chat templates.  For those models we flatten
+        # tool exchanges into plain assistant/user messages.
+        flatten_tools = self.model.startswith("ollama_chat/")
+
         if system_prompt:
             litellm_messages.append({"role": "system", "content": system_prompt})
 
         for msg in messages:
             if msg.role == "assistant" and msg.tool_calls:
-                # Assistant message with tool calls
-                litellm_messages.append({
-                    "role": "assistant",
-                    "content": msg.content,
-                    "tool_calls": [
-                        {
-                            "id": tc.id,
-                            "type": "function",
-                            "function": {
-                                "name": tc.name,
-                                "arguments": json.dumps(tc.arguments),
-                            },
-                        }
-                        for tc in msg.tool_calls
-                    ],
-                })
+                if flatten_tools:
+                    # Convert tool calls to plain text the model can understand
+                    parts = []
+                    if msg.content:
+                        parts.append(msg.content)
+                    for tc in msg.tool_calls:
+                        args_str = json.dumps(tc.arguments) if tc.arguments else "{}"
+                        parts.append(f"<|channel|>commentary to=functions.{tc.name} "
+                                     f"<|constrain|>json<|message|>{args_str}<|end|>")
+                    litellm_messages.append({
+                        "role": "assistant",
+                        "content": "\n".join(parts),
+                    })
+                else:
+                    litellm_messages.append({
+                        "role": "assistant",
+                        "content": msg.content,
+                        "tool_calls": [
+                            {
+                                "id": tc.id,
+                                "type": "function",
+                                "function": {
+                                    "name": tc.name,
+                                    "arguments": json.dumps(tc.arguments),
+                                },
+                            }
+                            for tc in msg.tool_calls
+                        ],
+                    })
             elif msg.role == "tool":
-                # Tool result message
-                litellm_messages.append({
-                    "role": "tool",
-                    "tool_call_id": msg.tool_call_id,
-                    "content": msg.content or "",
-                })
+                if flatten_tools:
+                    # Convert tool result to a user message
+                    litellm_messages.append({
+                        "role": "user",
+                        "content": f"[Tool result: {msg.content or ''}]",
+                    })
+                else:
+                    litellm_messages.append({
+                        "role": "tool",
+                        "tool_call_id": msg.tool_call_id,
+                        "content": msg.content or "",
+                    })
             else:
                 # Pass content as-is — LiteLLM/OpenAI natively support
                 # content block arrays for multimodal messages
@@ -350,6 +374,12 @@ class LiteLLMProvider(LLMProvider):
             )
 
         content = "".join(content_chunks) if content_chunks else None
+
+        # Fallback: extract tool calls from protocol tokens when the API
+        # didn't return structured tool_calls (common with local models).
+        if not tool_calls and content:
+            tool_calls = self._extract_tool_calls_from_protocol(content)
+
         if content:
             content = self._strip_protocol_tokens(content)
 
@@ -359,6 +389,47 @@ class LiteLLMProvider(LLMProvider):
             stop_reason=finish_reason,
             usage=usage,
         )
+
+    @staticmethod
+    def _extract_tool_calls_from_protocol(text: str) -> list[ToolCall]:
+        """Extract tool calls from model protocol tokens.
+
+        Some local models (e.g. gpt-oss via Pico) embed function calls in
+        protocol tokens instead of using the OpenAI tool_calls format:
+            <|channel|>commentary to=functions.NAME <|constrain|>json<|message|>ARGS
+
+        This parses those into proper ToolCall objects.
+        """
+        calls: list[ToolCall] = []
+        # Match: to=functions.NAME ... <|constrain|>json<|message|>ARGS
+        pattern = re.compile(
+            r"to=functions\.(\w+)\s*"           # function name
+            r"<\|constrain\|>json<\|message\|>"  # delimiter
+            r"(.*?)"                              # JSON arguments
+            r"(?:<\|end\|>|<\|start\|>|$)",       # end of block
+            re.DOTALL,
+        )
+        for match in pattern.finditer(text):
+            name = match.group(1)
+            raw_args = match.group(2).strip()
+            arguments: dict[str, Any] = {}
+            if raw_args:
+                try:
+                    arguments = json.loads(raw_args)
+                except json.JSONDecodeError:
+                    # Try to fix truncated JSON
+                    if not raw_args.endswith("}"):
+                        raw_args += "}"
+                    try:
+                        arguments = json.loads(raw_args)
+                    except json.JSONDecodeError:
+                        arguments = {"raw": raw_args}
+            calls.append(ToolCall(
+                id=f"call_{name}_{len(calls)}",
+                name=name,
+                arguments=arguments,
+            ))
+        return calls
 
     @staticmethod
     def _strip_protocol_tokens(text: str) -> str:
@@ -425,6 +496,12 @@ class LiteLLMProvider(LLMProvider):
                 )
 
         content = message.content
+
+        # Fallback: extract tool calls from protocol tokens when the API
+        # didn't return structured tool_calls (common with local models).
+        if not tool_calls and content:
+            tool_calls = self._extract_tool_calls_from_protocol(content)
+
         if content:
             content = self._strip_protocol_tokens(content)
 

--- a/src/macbot/skills/loader.py
+++ b/src/macbot/skills/loader.py
@@ -118,11 +118,18 @@ def load_skill_from_string(
         tasks = list(DEFAULT_COMMUNITY_TASKS)
         logger.debug(f"Skill '{skill_id}' has no tasks — assigned defaults")
 
+    # Parse essential_tasks (subset for compact context profiles)
+    essential_tasks: list[str] | None = None
+    if "essential_tasks" in frontmatter:
+        raw = frontmatter["essential_tasks"]
+        # Explicit empty list means "exclude in compact mode"
+        essential_tasks = ensure_list(raw) if raw is not None else []
+
     # Collect extra frontmatter fields into metadata
     known_fields = {
-        "id", "name", "description", "apps", "tasks", "examples",
-        "safe_defaults", "confirm_before_write", "requires_permissions",
-        "extends", "allowed-tools",
+        "id", "name", "description", "apps", "tasks", "essential_tasks",
+        "examples", "safe_defaults", "confirm_before_write",
+        "requires_permissions", "extends", "allowed-tools",
     }
     metadata = {k: v for k, v in frontmatter.items() if k not in known_fields}
 
@@ -133,6 +140,7 @@ def load_skill_from_string(
         description=frontmatter["description"],
         apps=ensure_list(frontmatter.get("apps")),
         tasks=tasks,
+        essential_tasks=essential_tasks,
         examples=ensure_list(frontmatter.get("examples")),
         safe_defaults=frontmatter.get("safe_defaults") or {},
         confirm_before_write=ensure_list(frontmatter.get("confirm_before_write")),

--- a/src/macbot/skills/models.py
+++ b/src/macbot/skills/models.py
@@ -34,6 +34,11 @@ class Skill(BaseModel):
         default_factory=list,
         description="Task names this skill provides guidance for",
     )
+    essential_tasks: list[str] | None = Field(
+        default=None,
+        description="Subset of tasks for compact/minimal context profiles (Pico). "
+        "None = fall back to full tasks list; [] = exclude skill entirely in compact mode.",
+    )
 
     # Guidance content
     examples: list[str] = Field(
@@ -85,17 +90,34 @@ class Skill(BaseModel):
         description="Whether this skill is currently enabled",
     )
 
-    def get_tool_schemas(self, task_registry: TaskRegistry) -> list[dict[str, Any]]:
+    def get_effective_tasks(self, compact: bool = False) -> list[str]:
+        """Return the task list appropriate for the context profile.
+
+        Args:
+            compact: If True, prefer essential_tasks when available.
+
+        Returns:
+            Task name list. When compact=True and essential_tasks is not None,
+            returns essential_tasks; otherwise returns full tasks list.
+        """
+        if compact and self.essential_tasks is not None:
+            return self.essential_tasks
+        return self.tasks
+
+    def get_tool_schemas(
+        self, task_registry: TaskRegistry, compact: bool = False,
+    ) -> list[dict[str, Any]]:
         """Get tool schemas for tasks this skill references.
 
         Args:
             task_registry: Registry of available tasks.
+            compact: If True, use essential_tasks when available.
 
         Returns:
             List of tool schemas for the skill's tasks.
         """
         schemas = []
-        for task_name in self.tasks:
+        for task_name in self.get_effective_tasks(compact):
             task = task_registry.get(task_name)
             if task:
                 schemas.append(task.to_tool_schema())
@@ -139,12 +161,14 @@ class Skill(BaseModel):
 
         Returns only essential info: name, description, tools, defaults,
         and confirmation rules. No examples, no body.
+        Uses essential_tasks when available.
         """
+        effective = self.get_effective_tasks(compact=True)
         lines = [f"### {self.name}"]
         lines.append(self.description)
 
-        if self.tasks:
-            lines.append(f"**Tools:** {', '.join(self.tasks)}")
+        if effective:
+            lines.append(f"**Tools:** {', '.join(effective)}")
 
         if self.safe_defaults:
             defaults_str = ", ".join(f"{k}={v}" for k, v in self.safe_defaults.items())

--- a/src/macbot/skills/registry.py
+++ b/src/macbot/skills/registry.py
@@ -137,12 +137,23 @@ class SkillsRegistry:
         ext_name = extension.name if extension.name != extension.id else base.name
         ext_description = extension.description if extension.description else base.description
 
+        # Merge essential_tasks: if both define it, merge and dedupe;
+        # if only one defines it, use that; if neither, None
+        merged_essential: list[str] | None = None
+        if base.essential_tasks is not None and extension.essential_tasks is not None:
+            merged_essential = dedupe_list(base.essential_tasks + extension.essential_tasks)
+        elif base.essential_tasks is not None:
+            merged_essential = base.essential_tasks
+        elif extension.essential_tasks is not None:
+            merged_essential = extension.essential_tasks
+
         return Skill(
             id=base.id,
             name=ext_name,
             description=ext_description,
             apps=dedupe_list(base.apps + extension.apps),
             tasks=dedupe_list(base.tasks + extension.tasks),
+            essential_tasks=merged_essential,
             examples=base.examples + extension.examples,  # Allow duplicates for examples
             safe_defaults={**base.safe_defaults, **extension.safe_defaults},
             confirm_before_write=dedupe_list(base.confirm_before_write + extension.confirm_before_write),
@@ -293,11 +304,14 @@ class SkillsRegistry:
         self._save_config()
         return True
 
-    def get_all_tool_schemas(self, task_registry: TaskRegistry) -> list[dict[str, Any]]:
+    def get_all_tool_schemas(
+        self, task_registry: TaskRegistry, compact: bool = False,
+    ) -> list[dict[str, Any]]:
         """Get tool schemas for all enabled skills.
 
         Args:
             task_registry: Registry of available tasks.
+            compact: If True, use essential_tasks; skip skills with empty essential_tasks.
 
         Returns:
             List of tool schemas (deduplicated by name).
@@ -306,7 +320,10 @@ class SkillsRegistry:
         seen: set[str] = set()
 
         for skill in self.list_enabled_skills():
-            for schema in skill.get_tool_schemas(task_registry):
+            # In compact mode, skip skills whose effective task list is empty
+            if compact and not skill.get_effective_tasks(compact=True):
+                continue
+            for schema in skill.get_tool_schemas(task_registry, compact=compact):
                 name = schema.get("name", "")
                 if name and name not in seen:
                     schemas.append(schema)
@@ -337,6 +354,9 @@ class SkillsRegistry:
 
         for skill in sorted(enabled, key=lambda s: s.name):
             if compact:
+                # Skip skills with empty effective tasks in compact mode
+                if not skill.get_effective_tasks(compact=True):
+                    continue
                 lines.append(skill.format_for_prompt_compact())
             else:
                 lines.append(skill.format_for_prompt(task_registry))

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1085,3 +1085,417 @@ Use git commands to manage repositories.
         assert skill is not None
         assert skill.name == "git-helper"
         assert skill.metadata["license"] == "MIT"
+
+
+class TestEssentialTasks:
+    """Tests for the essential_tasks field and compact mode behavior."""
+
+    def test_parse_essential_tasks_present(self) -> None:
+        """Test parsing a skill with essential_tasks defined."""
+        content = """---
+id: test
+name: Test
+description: Test
+tasks:
+  - task_a
+  - task_b
+  - task_c
+essential_tasks:
+  - task_a
+  - task_b
+---
+"""
+        skill = load_skill_from_string(content, is_builtin=True)
+
+        assert skill.essential_tasks == ["task_a", "task_b"]
+
+    def test_parse_essential_tasks_absent(self) -> None:
+        """Test that missing essential_tasks defaults to None."""
+        content = """---
+id: test
+name: Test
+description: Test
+tasks:
+  - task_a
+---
+"""
+        skill = load_skill_from_string(content, is_builtin=True)
+
+        assert skill.essential_tasks is None
+
+    def test_parse_essential_tasks_empty_list(self) -> None:
+        """Test parsing essential_tasks as an explicit empty list."""
+        content = """---
+id: test
+name: Test
+description: Test
+tasks:
+  - task_a
+essential_tasks: []
+---
+"""
+        skill = load_skill_from_string(content, is_builtin=True)
+
+        assert skill.essential_tasks == []
+
+    def test_get_effective_tasks_compact_with_essential(self) -> None:
+        """Test get_effective_tasks returns essential_tasks in compact mode."""
+        skill = Skill(
+            id="test", name="Test", description="Test",
+            tasks=["task_a", "task_b", "task_c"],
+            essential_tasks=["task_a"],
+        )
+
+        assert skill.get_effective_tasks(compact=True) == ["task_a"]
+
+    def test_get_effective_tasks_compact_without_essential(self) -> None:
+        """Test get_effective_tasks falls back to tasks when essential_tasks is None."""
+        skill = Skill(
+            id="test", name="Test", description="Test",
+            tasks=["task_a", "task_b"],
+            essential_tasks=None,
+        )
+
+        assert skill.get_effective_tasks(compact=True) == ["task_a", "task_b"]
+
+    def test_get_effective_tasks_compact_empty_essential(self) -> None:
+        """Test get_effective_tasks returns empty list when essential_tasks is []."""
+        skill = Skill(
+            id="test", name="Test", description="Test",
+            tasks=["task_a", "task_b"],
+            essential_tasks=[],
+        )
+
+        assert skill.get_effective_tasks(compact=True) == []
+
+    def test_get_effective_tasks_non_compact(self) -> None:
+        """Test get_effective_tasks always returns full tasks when not compact."""
+        skill = Skill(
+            id="test", name="Test", description="Test",
+            tasks=["task_a", "task_b", "task_c"],
+            essential_tasks=["task_a"],
+        )
+
+        assert skill.get_effective_tasks(compact=False) == ["task_a", "task_b", "task_c"]
+
+    def test_get_tool_schemas_compact(self) -> None:
+        """Test get_tool_schemas uses essential_tasks in compact mode."""
+        task_registry = create_default_registry()
+
+        skill = Skill(
+            id="test", name="Test", description="Test",
+            tasks=["get_system_info", "get_current_time"],
+            essential_tasks=["get_current_time"],
+        )
+
+        schemas = skill.get_tool_schemas(task_registry, compact=True)
+
+        assert len(schemas) == 1
+        assert schemas[0]["name"] == "get_current_time"
+
+    def test_get_tool_schemas_non_compact(self) -> None:
+        """Test get_tool_schemas uses full tasks when compact=False."""
+        task_registry = create_default_registry()
+
+        skill = Skill(
+            id="test", name="Test", description="Test",
+            tasks=["get_system_info", "get_current_time"],
+            essential_tasks=["get_current_time"],
+        )
+
+        schemas = skill.get_tool_schemas(task_registry, compact=False)
+
+        assert len(schemas) == 2
+
+    def test_registry_get_all_tool_schemas_compact_excludes_empty(self, tmp_path: Path) -> None:
+        """Test that get_all_tool_schemas(compact=True) excludes skills with empty essential_tasks."""
+        task_registry = create_default_registry()
+
+        builtin_dir = tmp_path / "builtin"
+
+        # Skill with essential_tasks=[]  (should be excluded)
+        excluded_dir = builtin_dir / "excluded"
+        excluded_dir.mkdir(parents=True)
+        (excluded_dir / "SKILL.md").write_text("""---
+id: excluded
+name: Excluded
+description: Should be excluded in compact mode
+tasks:
+  - get_system_info
+essential_tasks: []
+---
+""")
+        # Skill with essential_tasks subset (should be included)
+        included_dir = builtin_dir / "included"
+        included_dir.mkdir(parents=True)
+        (included_dir / "SKILL.md").write_text("""---
+id: included
+name: Included
+description: Included in compact mode
+tasks:
+  - get_system_info
+  - get_current_time
+essential_tasks:
+  - get_current_time
+---
+""")
+        registry = SkillsRegistry(
+            builtin_dir=builtin_dir,
+            user_dir=tmp_path / "user",
+            config_file=tmp_path / "config.json",
+        )
+
+        schemas = registry.get_all_tool_schemas(task_registry, compact=True)
+
+        names = [s["name"] for s in schemas]
+        assert "get_current_time" in names
+        # get_system_info should NOT be present because the only skill that has it
+        # in full tasks has essential_tasks=[], and the included skill only has
+        # get_current_time in essential_tasks
+        assert "get_system_info" not in names
+
+    def test_registry_get_all_tool_schemas_non_compact_includes_all(self, tmp_path: Path) -> None:
+        """Test that get_all_tool_schemas(compact=False) includes all enabled skills."""
+        task_registry = create_default_registry()
+
+        builtin_dir = tmp_path / "builtin"
+
+        skill_dir = builtin_dir / "skill1"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("""---
+id: skill1
+name: Skill 1
+description: Test
+tasks:
+  - get_system_info
+essential_tasks: []
+---
+""")
+        registry = SkillsRegistry(
+            builtin_dir=builtin_dir,
+            user_dir=tmp_path / "user",
+            config_file=tmp_path / "config.json",
+        )
+
+        schemas = registry.get_all_tool_schemas(task_registry, compact=False)
+
+        names = [s["name"] for s in schemas]
+        assert "get_system_info" in names
+
+    def test_format_for_prompt_compact_excludes_empty_essential(self, tmp_path: Path) -> None:
+        """Test that format_for_prompt(compact=True) excludes skills with empty essential_tasks."""
+        builtin_dir = tmp_path / "builtin"
+
+        excluded_dir = builtin_dir / "excluded"
+        excluded_dir.mkdir(parents=True)
+        (excluded_dir / "SKILL.md").write_text("""---
+id: excluded
+name: Excluded Skill
+description: Should not appear
+tasks:
+  - some_task
+essential_tasks: []
+---
+""")
+        included_dir = builtin_dir / "included"
+        included_dir.mkdir(parents=True)
+        (included_dir / "SKILL.md").write_text("""---
+id: included
+name: Included Skill
+description: Should appear
+tasks:
+  - task_a
+  - task_b
+essential_tasks:
+  - task_a
+---
+""")
+        registry = SkillsRegistry(
+            builtin_dir=builtin_dir,
+            user_dir=tmp_path / "user",
+            config_file=tmp_path / "config.json",
+        )
+
+        formatted = registry.format_for_prompt(compact=True)
+
+        assert "Included Skill" in formatted
+        assert "Excluded Skill" not in formatted
+
+    def test_format_for_prompt_compact_shows_essential_tools(self, tmp_path: Path) -> None:
+        """Test that compact prompt shows essential_tasks, not full tasks."""
+        builtin_dir = tmp_path / "builtin"
+
+        skill_dir = builtin_dir / "test"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("""---
+id: test
+name: Test Skill
+description: Test
+tasks:
+  - task_a
+  - task_b
+  - task_c
+essential_tasks:
+  - task_a
+---
+""")
+        registry = SkillsRegistry(
+            builtin_dir=builtin_dir,
+            user_dir=tmp_path / "user",
+            config_file=tmp_path / "config.json",
+        )
+
+        formatted = registry.format_for_prompt(compact=True)
+
+        assert "task_a" in formatted
+        assert "task_b" not in formatted
+        assert "task_c" not in formatted
+
+    def test_merge_skill_propagates_essential_tasks_both(self, tmp_path: Path) -> None:
+        """Test _merge_skill merges essential_tasks when both skills define it."""
+        builtin_dir = tmp_path / "builtin"
+        base_dir = builtin_dir / "base"
+        base_dir.mkdir(parents=True)
+        (base_dir / "SKILL.md").write_text("""---
+id: base
+name: Base Skill
+description: Base
+tasks:
+  - task_a
+  - task_b
+essential_tasks:
+  - task_a
+---
+""")
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "ext"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "SKILL.md").write_text("""---
+id: ext
+extends: base
+name: ext
+description: Extension
+tasks:
+  - task_c
+essential_tasks:
+  - task_c
+---
+""")
+        registry = SkillsRegistry(
+            builtin_dir=builtin_dir,
+            user_dir=user_dir,
+            config_file=tmp_path / "config.json",
+        )
+
+        skill = registry.get("base")
+        assert skill is not None
+        assert skill.essential_tasks == ["task_a", "task_c"]
+
+    def test_merge_skill_propagates_essential_tasks_base_only(self, tmp_path: Path) -> None:
+        """Test _merge_skill uses base essential_tasks when extension doesn't define it."""
+        builtin_dir = tmp_path / "builtin"
+        base_dir = builtin_dir / "base"
+        base_dir.mkdir(parents=True)
+        (base_dir / "SKILL.md").write_text("""---
+id: base
+name: Base Skill
+description: Base
+tasks:
+  - task_a
+essential_tasks:
+  - task_a
+---
+""")
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "ext"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "SKILL.md").write_text("""---
+id: ext
+extends: base
+name: ext
+description: Extension
+tasks:
+  - task_b
+---
+""")
+        registry = SkillsRegistry(
+            builtin_dir=builtin_dir,
+            user_dir=user_dir,
+            config_file=tmp_path / "config.json",
+        )
+
+        skill = registry.get("base")
+        assert skill is not None
+        assert skill.essential_tasks == ["task_a"]
+
+    def test_merge_skill_propagates_essential_tasks_neither(self, tmp_path: Path) -> None:
+        """Test _merge_skill leaves essential_tasks as None when neither defines it."""
+        builtin_dir = tmp_path / "builtin"
+        base_dir = builtin_dir / "base"
+        base_dir.mkdir(parents=True)
+        (base_dir / "SKILL.md").write_text("""---
+id: base
+name: Base Skill
+description: Base
+tasks:
+  - task_a
+---
+""")
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "ext"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "SKILL.md").write_text("""---
+id: ext
+extends: base
+name: ext
+description: Extension
+tasks:
+  - task_b
+---
+""")
+        registry = SkillsRegistry(
+            builtin_dir=builtin_dir,
+            user_dir=user_dir,
+            config_file=tmp_path / "config.json",
+        )
+
+        skill = registry.get("base")
+        assert skill is not None
+        assert skill.essential_tasks is None
+
+    def test_all_builtin_essential_tasks_are_subset_of_tasks(self) -> None:
+        """Verify all built-in essential_tasks are a subset of tasks."""
+        builtin_dir = get_builtin_skills_dir()
+        registry = SkillsRegistry(
+            builtin_dir=builtin_dir,
+            user_dir=Path("/nonexistent"),
+            config_file=Path("/tmp/test_skills_config_essential.json"),
+        )
+
+        for skill in registry.list_skills():
+            if not skill.is_builtin or skill.essential_tasks is None:
+                continue
+            for task_name in skill.essential_tasks:
+                assert task_name in skill.tasks, (
+                    f"Skill '{skill.id}' has essential_task '{task_name}' "
+                    f"not in tasks list: {skill.tasks}"
+                )
+
+    def test_all_builtin_essential_tasks_exist_in_registry(self) -> None:
+        """Verify all built-in essential_tasks reference actually existing tasks."""
+        task_registry = create_default_registry()
+        builtin_dir = get_builtin_skills_dir()
+        registry = SkillsRegistry(
+            builtin_dir=builtin_dir,
+            user_dir=Path("/nonexistent"),
+            config_file=Path("/tmp/test_skills_config_essential2.json"),
+        )
+
+        for skill in registry.list_skills():
+            if not skill.is_builtin or not skill.enabled or skill.essential_tasks is None:
+                continue
+            for task_name in skill.essential_tasks:
+                task = task_registry.get(task_name)
+                assert task is not None, (
+                    f"Skill '{skill.id}' essential_task '{task_name}' not found in task registry"
+                )


### PR DESCRIPTION
…ocol-token tool calling

Add essential_tasks field to SKILL.md frontmatter so compact/minimal context profiles (Pico) expose only the most important tools per skill. When absent, falls back to the full tasks list (backward compatible). When empty ([]), the skill is excluded entirely in compact mode.

- Add essential_tasks field + get_effective_tasks() to Skill model
- Parse essential_tasks in loader, wire compact flag through registry
- Create core_utilities skill for shell/file/time tools
- Add essential_tasks to all 18 built-in skills (8 excluded, 8 reduced, 2 unchanged)
- Fix protocol-token tool calling for local models (gpt-oss via Pico): extract tool calls from <|channel|>commentary to=functions.NAME patterns and flatten tool_call/tool roles to plain messages for Pico's chat template
- Add 18 tests covering parsing, effective tasks, compact schemas, merge propagation, and built-in validation