### PR TITLE
Add chat history persistence and auto-growing textarea to GUI

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "0.4.0",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.4.0",
+      "version": "0.4.8",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "son-of-simon"
-version = "0.4.6"
+version = "0.4.8"
 dependencies = [
  "dirs 5.0.1",
  "macos-accessibility-client",

--- a/app/src/lib/components/ChatPanel.svelte
+++ b/app/src/lib/components/ChatPanel.svelte
@@ -21,6 +21,9 @@
     Wrench,
     Check,
     X,
+    Plus,
+    Clock,
+    ChevronDown,
   } from "lucide-svelte";
 
   interface Props {
@@ -33,6 +36,7 @@
   let inputText = $state("");
   let inputEl: HTMLTextAreaElement | undefined = $state();
   let transcriptEl: HTMLDivElement | undefined = $state();
+  let showHistory = $state(false);
 
   // Track previous message count to detect new messages vs streaming updates
   let prevMessageCount = $state(0);
@@ -61,6 +65,23 @@
           });
         }
       }
+    }
+  });
+
+  // Auto-grow textarea based on content
+  $effect(() => {
+    // Track inputText to re-run on changes
+    const _ = inputText;
+    if (inputEl) {
+      inputEl.style.height = "auto";
+      inputEl.style.height = inputEl.scrollHeight + "px";
+    }
+  });
+
+  // Load conversation list when panel becomes visible
+  $effect(() => {
+    if (visible) {
+      chatStore.loadConversations();
     }
   });
 
@@ -106,6 +127,31 @@
   function formatTime(ts: number): string {
     return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
   }
+
+  function formatDate(ts: number): string {
+    const d = new Date(ts);
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    if (diffDays === 0) return "Today";
+    if (diffDays === 1) return "Yesterday";
+    if (diffDays < 7) return d.toLocaleDateString([], { weekday: "short" });
+    return d.toLocaleDateString([], { month: "short", day: "numeric" });
+  }
+
+  function handleNewChat() {
+    chatStore.newConversation();
+    showHistory = false;
+  }
+
+  async function handleLoadConversation(id: string) {
+    await chatStore.loadConversation(id);
+    showHistory = false;
+  }
+
+  async function handleDeleteConversation() {
+    await chatStore.deleteConversation(chatStore.conversationId);
+  }
 </script>
 
 {#if visible}
@@ -137,8 +183,46 @@
               {statusLabel(chatStore.connectionState)}
             </span>
           </div>
+          <!-- History dropdown toggle -->
+          {#if chatStore.conversations.length > 0}
+            <div class="relative">
+              <button
+                type="button"
+                class="flex items-center gap-1 px-2 py-1 text-xs text-text-muted hover:text-text hover:bg-bg-input rounded-lg transition-colors"
+                onclick={() => showHistory = !showHistory}
+                title="Conversation history"
+              >
+                <Clock class="w-3.5 h-3.5" />
+                <span>History</span>
+                <ChevronDown class="w-3 h-3 transition-transform {showHistory ? 'rotate-180' : ''}" />
+              </button>
+              {#if showHistory}
+                <div class="absolute top-full left-0 mt-1 w-64 max-h-80 overflow-y-auto bg-bg-card border border-border rounded-xl shadow-lg z-10">
+                  {#each chatStore.conversations as conv (conv.id)}
+                    <button
+                      type="button"
+                      class="w-full text-left px-3 py-2 hover:bg-bg-input transition-colors border-b border-border/50 last:border-b-0
+                        {conv.id === chatStore.conversationId ? 'bg-primary/10' : ''}"
+                      onclick={() => handleLoadConversation(conv.id)}
+                    >
+                      <div class="text-sm text-text truncate">{conv.title || "Untitled"}</div>
+                      <div class="text-[10px] text-text-muted">{formatDate(conv.updatedAt)}</div>
+                    </button>
+                  {/each}
+                </div>
+              {/if}
+            </div>
+          {/if}
         </div>
         <div class="flex items-center gap-1">
+          <button
+            type="button"
+            class="p-2 hover:bg-bg-input rounded-lg transition-colors text-text-muted hover:text-text"
+            onclick={handleNewChat}
+            title="New chat"
+          >
+            <Plus class="w-4 h-4" />
+          </button>
           {#if chatStore.connectionState === "error" || chatStore.connectionState === "disconnected"}
             <button
               type="button"
@@ -153,8 +237,8 @@
             <button
               type="button"
               class="p-2 hover:bg-bg-input rounded-lg transition-colors text-text-muted hover:text-text"
-              onclick={() => chatStore.clear()}
-              title="Clear transcript"
+              onclick={handleDeleteConversation}
+              title="Delete conversation"
             >
               <Trash2 class="w-4 h-4" />
             </button>
@@ -264,7 +348,7 @@
       <div class="border-t border-border p-4">
         <div class="flex gap-2">
           <textarea
-            class="flex-1 bg-bg-input border border-border rounded-xl px-3 py-2 text-sm text-text resize-none focus:outline-none focus:ring-2 focus:ring-primary/50 min-h-[40px] max-h-[120px]"
+            class="flex-1 bg-bg-input border border-border rounded-xl px-3 py-2 text-sm text-text resize-none focus:outline-none focus:ring-2 focus:ring-primary/50 min-h-[40px] max-h-[200px] overflow-y-auto"
             placeholder={chatStore.connectionState === "connected" ? "Type a message..." : "Connecting..."}
             disabled={chatStore.connectionState !== "connected" || chatStore.isStreaming}
             bind:value={inputText}

--- a/app/src/lib/stores/chat.svelte.ts
+++ b/app/src/lib/stores/chat.svelte.ts
@@ -1,5 +1,6 @@
 import { Command, type Child } from "@tauri-apps/plugin-shell";
-import { resourceDir, join, dirname } from "@tauri-apps/api/path";
+import { resourceDir, join, dirname, homeDir } from "@tauri-apps/api/path";
+import { readTextFile, writeTextFile, exists, mkdir, readDir, remove } from "@tauri-apps/plugin-fs";
 
 export interface ToolCall {
   name: string;
@@ -26,6 +27,21 @@ export interface AppPermissions {
   Safari: boolean;
 }
 
+export interface ConversationSummary {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface ConversationFile {
+  id: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+  messages: ChatMessage[];
+}
+
 type ConnectionState = "disconnected" | "connecting" | "connected" | "error";
 
 class ChatStore {
@@ -37,8 +53,12 @@ class ChatStore {
   private _telegramAssistantId: string | null = null;
   private _buffer = "";
   private _sonPath: string | null = null;
+  private _historyDir: string | null = null;
   private _permissions = $state<AppPermissions | null>(null);
   private _checkingPermissions = $state(false);
+  private _conversationId = $state<string>(crypto.randomUUID());
+  private _conversations = $state<ConversationSummary[]>([]);
+  private _conversationTitle = $state<string>("");
 
   get messages() {
     return this._messages;
@@ -66,6 +86,147 @@ class ChatStore {
 
   get checkingPermissions() {
     return this._checkingPermissions;
+  }
+
+  get conversationId() {
+    return this._conversationId;
+  }
+
+  get conversations() {
+    return this._conversations;
+  }
+
+  get conversationTitle() {
+    return this._conversationTitle;
+  }
+
+  private async getHistoryDir(): Promise<string> {
+    if (this._historyDir) return this._historyDir;
+    const home = await homeDir();
+    this._historyDir = await join(home, ".macbot", "chat-history");
+    return this._historyDir;
+  }
+
+  async saveConversation() {
+    if (this._messages.length === 0) return;
+
+    try {
+      const dir = await this.getHistoryDir();
+      await mkdir(dir, { recursive: true });
+
+      // Auto-generate title from first user message
+      if (!this._conversationTitle) {
+        const firstUser = this._messages.find((m) => m.role === "user");
+        if (firstUser) {
+          this._conversationTitle = firstUser.text.slice(0, 50).trim();
+          if (firstUser.text.length > 50) this._conversationTitle += "...";
+        }
+      }
+
+      const now = Date.now();
+      const data: ConversationFile = {
+        id: this._conversationId,
+        title: this._conversationTitle,
+        createdAt: this._messages[0]?.timestamp ?? now,
+        updatedAt: now,
+        messages: this._messages,
+      };
+
+      const filePath = await join(dir, `${this._conversationId}.json`);
+      await writeTextFile(filePath, JSON.stringify(data));
+
+      // Update summary in conversations list
+      const idx = this._conversations.findIndex((c) => c.id === this._conversationId);
+      const summary: ConversationSummary = {
+        id: data.id,
+        title: data.title,
+        createdAt: data.createdAt,
+        updatedAt: data.updatedAt,
+      };
+      if (idx !== -1) {
+        this._conversations[idx] = summary;
+      } else {
+        this._conversations = [summary, ...this._conversations];
+      }
+    } catch (e) {
+      console.error("Failed to save conversation:", e);
+    }
+  }
+
+  async loadConversations() {
+    try {
+      const dir = await this.getHistoryDir();
+      if (!(await exists(dir))) {
+        this._conversations = [];
+        return;
+      }
+
+      const entries = await readDir(dir);
+      const summaries: ConversationSummary[] = [];
+
+      for (const entry of entries) {
+        if (!entry.name?.endsWith(".json")) continue;
+        try {
+          const filePath = await join(dir, entry.name);
+          const content = await readTextFile(filePath);
+          const data = JSON.parse(content) as ConversationFile;
+          summaries.push({
+            id: data.id,
+            title: data.title,
+            createdAt: data.createdAt,
+            updatedAt: data.updatedAt,
+          });
+        } catch {
+          // Skip malformed files
+        }
+      }
+
+      summaries.sort((a, b) => b.updatedAt - a.updatedAt);
+      this._conversations = summaries;
+    } catch (e) {
+      console.error("Failed to load conversations:", e);
+    }
+  }
+
+  async loadConversation(id: string) {
+    try {
+      const dir = await this.getHistoryDir();
+      const filePath = await join(dir, `${id}.json`);
+      const content = await readTextFile(filePath);
+      const data = JSON.parse(content) as ConversationFile;
+
+      this._conversationId = data.id;
+      this._conversationTitle = data.title;
+      this._messages = data.messages;
+      this._currentAssistantId = null;
+    } catch (e) {
+      console.error("Failed to load conversation:", e);
+    }
+  }
+
+  newConversation() {
+    this._messages = [];
+    this._conversationId = crypto.randomUUID();
+    this._conversationTitle = "";
+    this._currentAssistantId = null;
+  }
+
+  async deleteConversation(id: string) {
+    try {
+      const dir = await this.getHistoryDir();
+      const filePath = await join(dir, `${id}.json`);
+      if (await exists(filePath)) {
+        await remove(filePath);
+      }
+      this._conversations = this._conversations.filter((c) => c.id !== id);
+
+      // If deleting the active conversation, start a new one
+      if (this._conversationId === id) {
+        this.newConversation();
+      }
+    } catch (e) {
+      console.error("Failed to delete conversation:", e);
+    }
   }
 
   private async getSonPath(): Promise<string> {
@@ -197,8 +358,7 @@ class ChatStore {
   }
 
   clear() {
-    this._messages = [];
-    this._currentAssistantId = null;
+    this.newConversation();
   }
 
   private _handleStdout(raw: string) {
@@ -350,6 +510,7 @@ class ChatStore {
               };
             }
             this._currentAssistantId = null;
+            this.saveConversation();
           }
           break;
 
@@ -366,6 +527,7 @@ class ChatStore {
               };
             }
             this._currentAssistantId = null;
+            this.saveConversation();
           } else {
             this._addSystemMessage(`Error: ${msg.text as string}`);
           }


### PR DESCRIPTION
Conversations are now saved as JSON files in ~/.macbot/chat-history/ and persist across app restarts. Adds a history dropdown to browse and load past conversations, a new-chat button, and delete-from-disk. The input textarea auto-grows with content up to 200px.