### PR TITLE
Add PDF support to read_file tool with multimodal vision fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "pyyaml>=6.0.0",
     "python-telegram-bot>=21.0",
     "msal>=1.28.0",
+    "pymupdf>=1.24.0",
 ]
 
 [project.optional-dependencies]

--- a/son.spec
+++ b/son.spec
@@ -130,6 +130,8 @@ a = Analysis(
         'tiktoken',
         'tiktoken_ext',
         'tiktoken_ext.openai_public',
+        'fitz',
+        'pymupdf',
     ],
     hookspath=[],
     hooksconfig={},

--- a/src/macbot/core/agent.py
+++ b/src/macbot/core/agent.py
@@ -682,12 +682,15 @@ On subsequent requests for the same site, **check memory first** (`memory_list`)
                     console.print(f"[red]  ✗ {tool_call.name} failed ({elapsed_str}):[/red] {result.error}")
 
             # Format and add tool result to messages
-            result_str = self._format_tool_result(result)
-            tool_msg = self.provider.format_tool_result(tool_call.id, result_str)
+            result_content = self._format_tool_result(result)
+            tool_msg = self.provider.format_tool_result(tool_call.id, result_content)
             self.messages.append(tool_msg)
 
-    def _format_tool_result(self, result: TaskResult) -> str:
-        """Format a task result as a string for the LLM.
+    def _format_tool_result(self, result: TaskResult) -> str | list[dict[str, Any]]:
+        """Format a task result for the LLM.
+
+        Returns a string for text results, or a list of content blocks for
+        multimodal results (e.g., PDF page images).
 
         Applies truncation based on context profile:
         - full: no truncation
@@ -695,6 +698,21 @@ On subsequent requests for the same site, **check memory first** (`memory_list`)
         - minimal: max 500 chars
         """
         if result.success:
+            # Check for multimodal PDF image output
+            if (
+                isinstance(result.output, dict)
+                and result.output.get("type") == "pdf_images"
+            ):
+                blocks: list[dict[str, Any]] = [
+                    {"type": "text", "text": result.output.get("text", "PDF document")}
+                ]
+                for b64_image in result.output.get("images", []):
+                    blocks.append({
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{b64_image}"},
+                    })
+                return blocks
+
             if isinstance(result.output, (dict, list)):
                 text = json.dumps(result.output)
             else:

--- a/src/macbot/providers/anthropic.py
+++ b/src/macbot/providers/anthropic.py
@@ -43,16 +43,53 @@ class AnthropicProvider(LLMProvider):
                 anthropic_messages.append({"role": "assistant", "content": content_blocks})
             elif msg.role == "tool":
                 # Tool result - Anthropic expects this as a user message with tool_result block
-                anthropic_messages.append({
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "tool_result",
-                            "tool_use_id": msg.tool_call_id,
-                            "content": msg.content or "",
-                        }
-                    ],
-                })
+                if isinstance(msg.content, list):
+                    # Multimodal tool result — convert content blocks to Anthropic format
+                    anthropic_tool_content: list[dict[str, Any]] = []
+                    for block in msg.content:
+                        if block.get("type") == "text":
+                            anthropic_tool_content.append(
+                                {"type": "text", "text": block["text"]}
+                            )
+                        elif block.get("type") == "image_url":
+                            url = block["image_url"]["url"]
+                            if url.startswith("data:"):
+                                header, b64_data = url.split(",", 1)
+                                media_type = header.split(":")[1].split(";")[0]
+                                anthropic_tool_content.append({
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": media_type,
+                                        "data": b64_data,
+                                    },
+                                })
+                            else:
+                                anthropic_tool_content.append({
+                                    "type": "image",
+                                    "source": {"type": "url", "url": url},
+                                })
+                    anthropic_messages.append({
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": msg.tool_call_id,
+                                "content": anthropic_tool_content,
+                            }
+                        ],
+                    })
+                else:
+                    anthropic_messages.append({
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": msg.tool_call_id,
+                                "content": msg.content or "",
+                            }
+                        ],
+                    })
             else:
                 if isinstance(msg.content, list):
                     # Convert OpenAI-format content blocks to Anthropic format
@@ -192,7 +229,9 @@ class AnthropicProvider(LLMProvider):
             usage=usage,
         )
 
-    def format_tool_result(self, tool_call_id: str, result: str) -> Message:
+    def format_tool_result(
+        self, tool_call_id: str, result: str | list[dict[str, Any]]
+    ) -> Message:
         """Format a tool result for Anthropic's format."""
         # Use unified Message format - conversion to Anthropic's format happens in chat()
         return Message(role="tool", content=result, tool_call_id=tool_call_id)

--- a/src/macbot/providers/base.py
+++ b/src/macbot/providers/base.py
@@ -116,7 +116,12 @@ class LLMProvider(ABC):
             elif isinstance(msg.content, list):
                 for block in msg.content:
                     if isinstance(block, dict):
-                        total_chars += len(str(block))
+                        if block.get("type") == "image_url":
+                            # Estimate ~1000 tokens (~3000 chars) per image
+                            # instead of stringifying the base64 data
+                            total_chars += 3000
+                        else:
+                            total_chars += len(str(block))
             if msg.tool_calls:
                 for tc in msg.tool_calls:
                     total_chars += len(tc.name) + len(str(tc.arguments))
@@ -125,12 +130,14 @@ class LLMProvider(ABC):
         return total_chars // 3
 
     @abstractmethod
-    def format_tool_result(self, tool_call_id: str, result: str) -> Message:
+    def format_tool_result(
+        self, tool_call_id: str, result: str | list[dict[str, Any]]
+    ) -> Message:
         """Format a tool result as a message.
 
         Args:
             tool_call_id: ID of the tool call
-            result: Result from the tool execution
+            result: Result from the tool execution (string or content blocks)
 
         Returns:
             Formatted message for the conversation

--- a/src/macbot/providers/litellm_provider.py
+++ b/src/macbot/providers/litellm_provider.py
@@ -122,10 +122,20 @@ class LiteLLMProvider(LLMProvider):
                         ],
                     })
                 elif msg.role == "tool":
+                    # Extract text-only for token estimation
+                    if isinstance(msg.content, list):
+                        text_parts = [
+                            block["text"]
+                            for block in msg.content
+                            if isinstance(block, dict) and block.get("type") == "text"
+                        ]
+                        est_content = "\n".join(text_parts) if text_parts else ""
+                    else:
+                        est_content = msg.content or ""
                     litellm_messages.append({
                         "role": "tool",
                         "tool_call_id": msg.tool_call_id,
-                        "content": msg.content or "",
+                        "content": est_content,
                     })
                 else:
                     litellm_messages.append({
@@ -215,17 +225,28 @@ class LiteLLMProvider(LLMProvider):
                         ],
                     })
             elif msg.role == "tool":
+                # Extract text-only content for tool results (images not supported)
+                if isinstance(msg.content, list):
+                    text_parts = [
+                        block["text"]
+                        for block in msg.content
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    ]
+                    tool_text = "\n".join(text_parts) if text_parts else ""
+                else:
+                    tool_text = msg.content or ""
+
                 if flatten_tools:
                     # Convert tool result to a user message
                     litellm_messages.append({
                         "role": "user",
-                        "content": f"[Tool result: {msg.content or ''}]",
+                        "content": f"[Tool result: {tool_text}]",
                     })
                 else:
                     litellm_messages.append({
                         "role": "tool",
                         "tool_call_id": msg.tool_call_id,
-                        "content": msg.content or "",
+                        "content": tool_text,
                     })
             else:
                 # Pass content as-is — LiteLLM/OpenAI natively support
@@ -516,12 +537,14 @@ class LiteLLMProvider(LLMProvider):
             },
         )
 
-    def format_tool_result(self, tool_call_id: str, result: str) -> Message:
+    def format_tool_result(
+        self, tool_call_id: str, result: str | list[dict[str, Any]]
+    ) -> Message:
         """Format a tool result as a message.
 
         Args:
             tool_call_id: ID of the tool call
-            result: Result from the tool execution
+            result: Result from the tool execution (string or content blocks)
 
         Returns:
             Formatted message for the conversation

--- a/src/macbot/providers/openai.py
+++ b/src/macbot/providers/openai.py
@@ -57,11 +57,21 @@ class OpenAIProvider(LLMProvider):
                 }
                 openai_messages.append(openai_msg)
             elif msg.role == "tool":
-                # Tool result message
+                # Tool result message — OpenAI doesn't support images in tool results
+                if isinstance(msg.content, list):
+                    # Extract text blocks only
+                    text_parts = [
+                        block["text"]
+                        for block in msg.content
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    ]
+                    tool_content = "\n".join(text_parts) if text_parts else ""
+                else:
+                    tool_content = msg.content or ""
                 openai_messages.append({
                     "role": "tool",
                     "tool_call_id": msg.tool_call_id,
-                    "content": msg.content or "",
+                    "content": tool_content,
                 })
             else:
                 # Pass content as-is — OpenAI natively supports
@@ -206,7 +216,9 @@ class OpenAIProvider(LLMProvider):
             usage=usage,
         )
 
-    def format_tool_result(self, tool_call_id: str, result: str) -> Message:
+    def format_tool_result(
+        self, tool_call_id: str, result: str | list[dict[str, Any]]
+    ) -> Message:
         """Format a tool result for OpenAI's format."""
         # OpenAI expects tool results as tool messages with tool_call_id
         return Message(role="tool", content=result, tool_call_id=tool_call_id)

--- a/src/macbot/tasks/file_read.py
+++ b/src/macbot/tasks/file_read.py
@@ -1,23 +1,32 @@
 """Task: Read File
 
-Read content from a file on the filesystem.
+Read content from a file on the filesystem, including PDF support.
 """
 
+import base64
+import logging
 import os
+from typing import Any
 
 from macbot.tasks.base import Task
 from macbot.tasks.registry import task_registry
+
+logger = logging.getLogger(__name__)
 
 
 class ReadFileTask(Task):
     """Read content from a file.
 
     Reads file content with configurable maximum character limit.
+    For PDF files, extracts text or renders pages as images for vision-capable LLMs.
 
     Example:
         task = ReadFileTask()
         result = await task.execute(path="/tmp/test.txt")
         # Returns file content as string
+
+        result = await task.execute(path="/tmp/document.pdf")
+        # Returns extracted text, or dict with page images for scanned PDFs
     """
 
     @property
@@ -28,26 +37,103 @@ class ReadFileTask(Task):
     @property
     def description(self) -> str:
         """Get the task description."""
-        return "Read and return the content of a file."
+        return "Read and return the content of a file. Supports text files and PDFs (text extraction with image fallback for scanned documents)."
 
-    async def execute(self, path: str, max_chars: int = 10000) -> str:
+    async def execute(
+        self, path: str, max_chars: int = 10000, max_pages: int = 5
+    ) -> str | dict[str, Any]:
         """Read content from a file.
 
         Args:
             path: File path to read from.
-            max_chars: Maximum characters to return.
+            max_chars: Maximum characters to return (for text content).
+            max_pages: Maximum pages to render as images (for scanned PDFs).
 
         Returns:
-            File content as string.
+            File content as string, or dict with page images for scanned PDFs.
 
         Raises:
             FileNotFoundError: If the file does not exist.
             PermissionError: If the file cannot be read.
         """
         path = os.path.expanduser(path)
+
+        if path.lower().endswith(".pdf"):
+            return self._read_pdf(path, max_chars, max_pages)
+
         with open(path) as f:
             content = f.read(max_chars)
         return content
+
+    def _read_pdf(
+        self, path: str, max_chars: int, max_pages: int
+    ) -> str | dict[str, Any]:
+        """Read a PDF file, extracting text or rendering pages as images.
+
+        Args:
+            path: Absolute path to the PDF file.
+            max_chars: Maximum characters for text extraction.
+            max_pages: Maximum pages to render as images.
+
+        Returns:
+            Extracted text as string if the PDF has meaningful text content,
+            or a dict with type="pdf_images" containing base64-encoded page images.
+        """
+        try:
+            import pymupdf
+        except ImportError:
+            raise RuntimeError(
+                "pymupdf is required for PDF support. Install it with: pip install pymupdf"
+            )
+
+        try:
+            doc = pymupdf.open(path)
+        except Exception as e:
+            error_msg = str(e).lower()
+            if "password" in error_msg or "encrypted" in error_msg:
+                raise PermissionError(f"PDF is password-protected: {path}") from e
+            raise ValueError(f"Could not open PDF: {e}") from e
+
+        try:
+            # Extract text from all pages
+            text_parts: list[str] = []
+            for page in doc:
+                text = page.get_text()
+                if text.strip():
+                    text_parts.append(text)
+
+            full_text = "\n".join(text_parts)
+
+            # If meaningful text found (>100 chars), return as text
+            if len(full_text.strip()) > 100:
+                if len(full_text) > max_chars:
+                    full_text = full_text[:max_chars]
+                return full_text
+
+            # Image-based PDF: render pages as PNG images
+            pages_to_render = min(len(doc), max_pages)
+            images: list[str] = []
+
+            for i in range(pages_to_render):
+                page = doc[i]
+                # Render at 150 DPI for good quality without excessive size
+                pix = page.get_pixmap(dpi=150)
+                png_data = pix.tobytes("png")
+                b64_data = base64.b64encode(png_data).decode("ascii")
+                images.append(b64_data)
+
+            summary = f"Scanned PDF: {len(doc)} page(s)"
+            if full_text.strip():
+                summary += f", minimal text extracted: {full_text.strip()[:200]}"
+
+            return {
+                "type": "pdf_images",
+                "text": summary,
+                "pages": len(doc),
+                "images": images,
+            }
+        finally:
+            doc.close()
 
 
 # Auto-register on import

--- a/tests/test_file_read_pdf.py
+++ b/tests/test_file_read_pdf.py
@@ -1,0 +1,401 @@
+"""Tests for PDF support in ReadFileTask and multimodal tool result handling."""
+
+import base64
+import json
+import os
+import tempfile
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers to create test PDFs
+# ---------------------------------------------------------------------------
+
+def _create_text_pdf(path: str, text: str = "Hello, this is a test PDF with enough text to be considered meaningful content. " * 5) -> None:
+    """Create a simple text-based PDF using pymupdf."""
+    import pymupdf
+
+    doc = pymupdf.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), text)
+    doc.save(path)
+    doc.close()
+
+
+def _create_image_pdf(path: str) -> None:
+    """Create a PDF with only an image (no extractable text)."""
+    import pymupdf
+
+    doc = pymupdf.open()
+    page = doc.new_page()
+    # Draw a filled rectangle — no text at all
+    page.draw_rect(pymupdf.Rect(50, 50, 200, 200), color=(1, 0, 0), fill=(0, 0, 1))
+    doc.save(path)
+    doc.close()
+
+
+def _create_multipage_image_pdf(path: str, num_pages: int = 8) -> None:
+    """Create a multi-page PDF with only images."""
+    import pymupdf
+
+    doc = pymupdf.open()
+    for i in range(num_pages):
+        page = doc.new_page()
+        page.draw_rect(pymupdf.Rect(50, 50, 200, 200), color=(0, i / num_pages, 0), fill=(1, 0, 0))
+    doc.save(path)
+    doc.close()
+
+
+# ---------------------------------------------------------------------------
+# ReadFileTask tests
+# ---------------------------------------------------------------------------
+
+class TestReadFileTaskPDF:
+    """Tests for PDF reading in ReadFileTask."""
+
+    @pytest.mark.asyncio
+    async def test_text_pdf_returns_string(self, tmp_path: Any) -> None:
+        """Text-based PDF returns extracted text as a string."""
+        from macbot.tasks.file_read import ReadFileTask
+
+        pdf_path = str(tmp_path / "text.pdf")
+        _create_text_pdf(pdf_path)
+
+        task = ReadFileTask()
+        result = await task.execute(path=pdf_path)
+
+        assert isinstance(result, str)
+        assert "Hello" in result
+
+    @pytest.mark.asyncio
+    async def test_image_pdf_returns_dict(self, tmp_path: Any) -> None:
+        """Image-only PDF returns dict with type=pdf_images and base64 images."""
+        from macbot.tasks.file_read import ReadFileTask
+
+        pdf_path = str(tmp_path / "image.pdf")
+        _create_image_pdf(pdf_path)
+
+        task = ReadFileTask()
+        result = await task.execute(path=pdf_path)
+
+        assert isinstance(result, dict)
+        assert result["type"] == "pdf_images"
+        assert result["pages"] == 1
+        assert len(result["images"]) == 1
+        # Verify it's valid base64 PNG
+        decoded = base64.b64decode(result["images"][0])
+        assert decoded[:4] == b"\x89PNG"
+
+    @pytest.mark.asyncio
+    async def test_max_pages_limits_images(self, tmp_path: Any) -> None:
+        """max_pages parameter caps the number of rendered images."""
+        from macbot.tasks.file_read import ReadFileTask
+
+        pdf_path = str(tmp_path / "multi.pdf")
+        _create_multipage_image_pdf(pdf_path, num_pages=8)
+
+        task = ReadFileTask()
+        result = await task.execute(path=pdf_path, max_pages=3)
+
+        assert isinstance(result, dict)
+        assert result["pages"] == 8  # total pages in PDF
+        assert len(result["images"]) == 3  # but only 3 rendered
+
+    @pytest.mark.asyncio
+    async def test_max_chars_truncates_text_pdf(self, tmp_path: Any) -> None:
+        """max_chars truncates text extracted from a text PDF."""
+        import pymupdf
+
+        from macbot.tasks.file_read import ReadFileTask
+
+        pdf_path = str(tmp_path / "long.pdf")
+        # Insert text on many lines to ensure >100 chars extracted
+        doc = pymupdf.open()
+        page = doc.new_page()
+        line = "This is a long line of text for testing truncation. "
+        for i in range(50):
+            page.insert_text((72, 72 + i * 14), line)
+        doc.save(pdf_path)
+        doc.close()
+
+        task = ReadFileTask()
+        result = await task.execute(path=pdf_path, max_chars=200)
+
+        assert isinstance(result, str)
+        assert len(result) <= 200
+
+    @pytest.mark.asyncio
+    async def test_non_pdf_unchanged(self, tmp_path: Any) -> None:
+        """Non-PDF files still return plain string content."""
+        from macbot.tasks.file_read import ReadFileTask
+
+        txt_path = str(tmp_path / "hello.txt")
+        with open(txt_path, "w") as f:
+            f.write("plain text content")
+
+        task = ReadFileTask()
+        result = await task.execute(path=txt_path)
+
+        assert isinstance(result, str)
+        assert result == "plain text content"
+
+    @pytest.mark.asyncio
+    async def test_file_not_found(self) -> None:
+        """Missing file raises FileNotFoundError."""
+        from macbot.tasks.file_read import ReadFileTask
+
+        task = ReadFileTask()
+        with pytest.raises(FileNotFoundError):
+            await task.execute(path="/nonexistent/file.txt")
+
+    @pytest.mark.asyncio
+    async def test_corrupted_pdf(self, tmp_path: Any) -> None:
+        """Corrupted PDF raises ValueError."""
+        from macbot.tasks.file_read import ReadFileTask
+
+        bad_path = str(tmp_path / "bad.pdf")
+        with open(bad_path, "wb") as f:
+            f.write(b"this is not a PDF at all")
+
+        task = ReadFileTask()
+        with pytest.raises(ValueError, match="Could not open PDF"):
+            await task.execute(path=bad_path)
+
+    @pytest.mark.asyncio
+    async def test_description_mentions_pdf(self) -> None:
+        """Tool description mentions PDF support."""
+        from macbot.tasks.file_read import ReadFileTask
+
+        task = ReadFileTask()
+        assert "PDF" in task.description or "pdf" in task.description.lower()
+
+    @pytest.mark.asyncio
+    async def test_tool_schema_includes_max_pages(self) -> None:
+        """Tool schema includes max_pages parameter."""
+        from macbot.tasks.file_read import ReadFileTask
+
+        task = ReadFileTask()
+        schema = task.to_tool_schema()
+        props = schema["input_schema"]["properties"]
+        assert "max_pages" in props
+
+
+# ---------------------------------------------------------------------------
+# Agent _format_tool_result tests
+# ---------------------------------------------------------------------------
+
+class TestFormatToolResultPDF:
+    """Tests for _format_tool_result handling pdf_images output."""
+
+    def _make_agent(self) -> Any:
+        """Create a minimal Agent for testing _format_tool_result."""
+        from macbot.core.task import TaskResult
+
+        # We need an Agent instance — mock out the heavy parts
+        with patch("macbot.core.agent.get_default_registry"), \
+             patch("macbot.core.agent.LiteLLMProvider"), \
+             patch("macbot.core.agent.settings") as mock_settings:
+            mock_settings.get_model.return_value = "anthropic/claude-sonnet-4-20250514"
+            mock_settings.get_api_key_for_model.return_value = "test-key"
+            mock_settings.get_api_base_for_model.return_value = None
+            mock_settings.context_profile = "full"
+            mock_settings.max_iterations = 10
+            mock_settings.agent_system_prompt = "test"
+
+            from macbot.core.agent import Agent
+            from macbot.core.task import TaskRegistry
+            agent = Agent(task_registry=TaskRegistry())
+
+        return agent
+
+    def test_pdf_images_returns_content_blocks(self) -> None:
+        """pdf_images output produces a list of content blocks."""
+        from macbot.core.task import TaskResult
+
+        agent = self._make_agent()
+        result = TaskResult(
+            success=True,
+            output={
+                "type": "pdf_images",
+                "text": "Scanned PDF: 2 pages",
+                "pages": 2,
+                "images": ["aGVsbG8=", "d29ybGQ="],
+            },
+        )
+
+        formatted = agent._format_tool_result(result)
+
+        assert isinstance(formatted, list)
+        assert formatted[0]["type"] == "text"
+        assert formatted[0]["text"] == "Scanned PDF: 2 pages"
+        assert formatted[1]["type"] == "image_url"
+        assert formatted[1]["image_url"]["url"].startswith("data:image/png;base64,")
+        assert formatted[2]["type"] == "image_url"
+
+    def test_plain_dict_returns_string(self) -> None:
+        """A regular dict (not pdf_images) returns JSON string."""
+        from macbot.core.task import TaskResult
+
+        agent = self._make_agent()
+        result = TaskResult(
+            success=True,
+            output={"key": "value"},
+        )
+
+        formatted = agent._format_tool_result(result)
+
+        assert isinstance(formatted, str)
+        assert json.loads(formatted) == {"key": "value"}
+
+    def test_error_returns_string(self) -> None:
+        """Error results always return a string."""
+        from macbot.core.task import TaskResult
+
+        agent = self._make_agent()
+        result = TaskResult(success=False, output=None, error="something broke")
+
+        formatted = agent._format_tool_result(result)
+
+        assert isinstance(formatted, str)
+        assert "Error: something broke" in formatted
+
+
+# ---------------------------------------------------------------------------
+# Provider multimodal tool result handling
+# ---------------------------------------------------------------------------
+
+class TestAnthropicMultimodalToolResult:
+    """Tests that Anthropic provider converts image blocks in tool results."""
+
+    def test_multimodal_tool_result_conversion(self) -> None:
+        """Multimodal tool result is converted to Anthropic format."""
+        from macbot.providers.anthropic import AnthropicProvider
+        from macbot.providers.base import Message
+
+        provider = AnthropicProvider.__new__(AnthropicProvider)
+        provider.model = "claude-sonnet-4-20250514"
+
+        content_blocks = [
+            {"type": "text", "text": "Scanned PDF"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,aGVsbG8="}},
+        ]
+
+        msg = provider.format_tool_result("call_123", content_blocks)
+
+        assert msg.role == "tool"
+        assert msg.tool_call_id == "call_123"
+        assert isinstance(msg.content, list)
+
+    def test_string_tool_result_unchanged(self) -> None:
+        """String tool result stays as string."""
+        from macbot.providers.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider.__new__(AnthropicProvider)
+        provider.model = "claude-sonnet-4-20250514"
+
+        msg = provider.format_tool_result("call_123", "plain text result")
+
+        assert msg.content == "plain text result"
+
+
+class TestOpenAIMultimodalFallback:
+    """Tests that OpenAI extracts text-only from multimodal tool results."""
+
+    def test_multimodal_tool_result_text_only(self) -> None:
+        """OpenAI format_tool_result stores content blocks; chat() extracts text."""
+        from macbot.providers.openai import OpenAIProvider
+
+        provider = OpenAIProvider.__new__(OpenAIProvider)
+        provider.model = "gpt-4o"
+
+        content_blocks = [
+            {"type": "text", "text": "Scanned PDF"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,aGVsbG8="}},
+        ]
+
+        msg = provider.format_tool_result("call_123", content_blocks)
+
+        # The message stores the raw content blocks
+        assert isinstance(msg.content, list)
+
+    def test_string_tool_result_unchanged(self) -> None:
+        """String tool result stays as string."""
+        from macbot.providers.openai import OpenAIProvider
+
+        provider = OpenAIProvider.__new__(OpenAIProvider)
+        provider.model = "gpt-4o"
+
+        msg = provider.format_tool_result("call_123", "plain text")
+
+        assert msg.content == "plain text"
+
+
+class TestLiteLLMMultimodalFallback:
+    """Tests that LiteLLM extracts text-only from multimodal tool results."""
+
+    def test_multimodal_tool_result_stored(self) -> None:
+        """LiteLLM format_tool_result stores content blocks."""
+        from macbot.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider.__new__(LiteLLMProvider)
+        provider.model = "anthropic/claude-sonnet-4-20250514"
+
+        content_blocks = [
+            {"type": "text", "text": "Scanned PDF"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,aGVsbG8="}},
+        ]
+
+        msg = provider.format_tool_result("call_123", content_blocks)
+
+        assert isinstance(msg.content, list)
+
+    def test_string_tool_result_unchanged(self) -> None:
+        """String tool result stays as string."""
+        from macbot.providers.litellm_provider import LiteLLMProvider
+
+        provider = LiteLLMProvider.__new__(LiteLLMProvider)
+        provider.model = "anthropic/claude-sonnet-4-20250514"
+
+        msg = provider.format_tool_result("call_123", "plain text")
+
+        assert msg.content == "plain text"
+
+
+# ---------------------------------------------------------------------------
+# Token estimation with images
+# ---------------------------------------------------------------------------
+
+class TestTokenEstimationImages:
+    """Tests that image blocks use fixed estimate instead of stringifying base64."""
+
+    def test_image_block_fixed_estimate(self) -> None:
+        """Image blocks contribute ~3000 chars to estimate, not base64 length."""
+        from macbot.providers.base import Message
+
+        # Create a mock provider to test estimate_tokens
+        class TestProvider:
+            pass
+
+        from macbot.providers.base import LLMProvider
+        # Use the base class method directly
+        large_b64 = "A" * 100000  # ~100KB of fake base64
+        messages = [
+            Message(
+                role="tool",
+                content=[
+                    {"type": "text", "text": "PDF page"},
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{large_b64}"}},
+                ],
+                tool_call_id="call_1",
+            ),
+        ]
+
+        estimate = LLMProvider.estimate_tokens(None, messages)  # type: ignore[arg-type]
+
+        # With the fix, the estimate should be much less than if we stringified the base64
+        # 3000 (image) + ~50 (text block str) = ~3050 chars → ~1000 tokens
+        # Without fix: ~100000 chars → ~33000 tokens
+        assert estimate < 5000


### PR DESCRIPTION
Enable read_file to handle PDFs: text-based PDFs return extracted text, while scanned/image-only PDFs render pages as PNG images and pass them through the LLM's vision capabilities. Updates the agent loop and all provider implementations to support multimodal content blocks in tool results (Anthropic natively, OpenAI/LiteLLM fall back to text-only).